### PR TITLE
refactor(2) : entity 변경 및 enum 추가 

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -1,21 +1,38 @@
 package programmers.team6.domain.member.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.io.Serializable;
 
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import org.springframework.boot.autoconfigure.web.WebProperties.Resources.Chain.Strategy;
 
 @Entity
-public class Code {
-	@Id
-	@EmbeddedId
-	private CodeId codeId;
-	private String groupName;
-	private String codeName;
-
-	private static class CodeId implements Serializable {
-		private Integer groupId;
-		private Integer codeId;
+@Table(
+	name = "code",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"group_code", "code"})
 	}
+)
+public class Code {
+
+	@Id
+	@Column(name = "code_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "group_code", nullable = false)
+	private String groupCode;
+
+	@Column(nullable = false)
+	private String code;
+
+	@Column(nullable = false)
+	private String name;
+
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -1,16 +1,12 @@
 package programmers.team6.domain.member.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.io.Serializable;
-
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import org.springframework.boot.autoconfigure.web.WebProperties.Resources.Chain.Strategy;
 
 @Entity
 @Table(

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -7,8 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
 	name = "code",
 	uniqueConstraints = {
@@ -31,4 +35,10 @@ public class Code {
 	@Column(nullable = false)
 	private String name;
 
+	@Builder
+	public Code(String groupCode, String code, String name) {
+		this.groupCode = groupCode;
+		this.code = code;
+		this.name = name;
+	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
@@ -7,8 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Dept {
 	@Id
 	@Column(name = "dept_id")

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
@@ -1,16 +1,25 @@
 package programmers.team6.domain.member.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 
 @Entity
 public class Dept {
 	@Id
+	@Column(name = "dept_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(nullable = false)
 	private String deptName;
+
+	@OneToOne
+	@JoinColumn(name = "dept_leader_id", nullable = false)
 	private Member deptLeader;
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
@@ -2,9 +2,15 @@ package programmers.team6.domain.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import programmers.team6.domain.member.enums.Role;
 import programmers.team6.global.entity.BaseEntity;
 
 @Entity
@@ -14,8 +20,19 @@ public class Member extends BaseEntity {
 	@Column(name = "member_id")
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(nullable = false)
 	private String name;
-	private int deptId;
-	private int positionId;
-	private String adminYN;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "dept_id", nullable = false)
+	private Dept dept;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "position_id", nullable = false)
+	private Code position;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Role role;
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
@@ -10,10 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import programmers.team6.domain.member.enums.Role;
 import programmers.team6.global.entity.BaseEntity;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/MemberInfo.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/MemberInfo.java
@@ -6,9 +6,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import programmers.team6.global.entity.BaseEntity;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberInfo extends BaseEntity {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/MemberInfo.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/MemberInfo.java
@@ -1,5 +1,6 @@
 package programmers.team6.domain.member.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -11,17 +12,18 @@ import programmers.team6.global.entity.BaseEntity;
 public class MemberInfo extends BaseEntity {
 
 	@Id
-	private Long memberId;
-
-	@OneToOne
 	@MapsId
+	@OneToOne
 	@JoinColumn(name = "member_id")
 	private Member member;
 
+	@Column(nullable = false)
 	private int birth;
 
+	@Column(nullable = false)
 	private String email;
 
+	@Column(nullable = false)
 	private String password;
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/enums/Role.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/enums/Role.java
@@ -1,0 +1,5 @@
+package programmers.team6.domain.member.enums;
+
+public enum Role {
+	USER, ADMIN
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationInfo.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationInfo.java
@@ -4,8 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VacationInfo {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
@@ -21,18 +21,20 @@ public class VacationRequest {
 	@Column(name = "vacation_request_id")
 	private Long id;
 
+	@Column(name = "from_date", nullable = false)
 	private LocalDateTime from;
 
+	@Column(name = "to_date", nullable = false)
 	private LocalDateTime to;
 
 	private String reason;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "code", nullable = false)
+	@JoinColumn(name = "type_code", nullable = false)
 	private Code type;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "code", nullable = false)
+	@JoinColumn(name = "status_code", nullable = false)
 	private Code status;
 
 	@Version

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
@@ -11,9 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import programmers.team6.domain.member.entity.Code;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VacationRequest {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/entity/VacationRequest.java
@@ -4,9 +4,12 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Version;
 import programmers.team6.domain.member.entity.Code;
 
@@ -17,11 +20,21 @@ public class VacationRequest {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "vacation_request_id")
 	private Long id;
+
 	private LocalDateTime from;
+
 	private LocalDateTime to;
+
 	private String reason;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "code", nullable = false)
 	private Code type;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "code", nullable = false)
+	private Code status;
+
 	@Version
 	private Integer version;
-	private Code status;
 }

--- a/backend/team6/src/main/java/programmers/team6/global/entity/BaseEntity.java
+++ b/backend/team6/src/main/java/programmers/team6/global/entity/BaseEntity.java
@@ -14,8 +14,10 @@ import lombok.Getter;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
+
 	@CreatedDate
 	private LocalDateTime createdAt;
+	
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 }


### PR DESCRIPTION

## #️⃣연관된 이슈 번호
- #2 

## 📝작업 내용
- Entity 연관관계, role enum 추가 

1. Code 
```java
@Entity
@Table(
	name = "code",
	uniqueConstraints = {
		@UniqueConstraint(columnNames = {"group_code", "code"})
	}
)
public class Code {

	@Id
	@Column(name = "code_id")
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	@Column(name = "group_code", nullable = false)
	private String groupCode;

	@Column(nullable = false)
	private String code;

	@Column(nullable = false)
	private String name;

}
``` 
- 기존에 groupCode + code로 복합키를 설정했는데요. 
- 이부분이 JPA에서 연관관계로 구현할 때 더 번거롭다고 생각이 들어서 
- pk 는 id 로 놓고 groupCode + code 를 유니크로 설정하는 방향으로 변경했습니다.
- 복합키로 유지한다면 연관관계 매핑을 할 때 아래와 같이 설정해야하고, 구현할 때도 번거로워 질거라고 생각했습니다.
```java
@JoinColumns({
    @JoinColumn(name = "group_id", referencedColumnName = "groupId"),
    @JoinColumn(name = "code_id", referencedColumnName = "codeId")
})
private Code position;
``` 

2. dept 

```java
@Entity
public class Dept {
	@Id
	@Column(name = "dept_id")
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	@Column(nullable = false)
	private String deptName;

	@OneToOne
	@JoinColumn(name = "dept_leader_id", nullable = false)
	private Member deptLeader;

}
``` 
- nullable = false 조건을 추가하였고, membr 엔티티와 1:1 연관관계를 설정하였습니다. 

3. member 

```java
@Entity
public class Member extends BaseEntity {

	@Id
	@Column(name = "member_id")
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private Long id;

	@Column(nullable = false)
	private String name;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "dept_id", nullable = false)
	private Dept dept;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "position_id", nullable = false)
	private Code position;

	@Column(nullable = false)
	@Enumerated(EnumType.STRING)
	private Role role;
}
``` 
- nullable = false 추가 
- dept, code 연관관계 설정
- adminYN -> role 변경 

4. memberInfo 
```java
@Entity
public class MemberInfo extends BaseEntity {

	@Id
	@MapsId
	@OneToOne
	@JoinColumn(name = "member_id")
	private Member member;

	@Column(nullable = false)
	private int birth;

	@Column(nullable = false)
	private String email;

	@Column(nullable = false)
	private String password;

}

``` 
- MapsId가 있길래 기존에 long id는 삭제하였습니다. 
- nullable =false 추가 

5. VacationInfo 
```java
@Entity
public class VacationInfo {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	private int vacationId;

	private int totalCount;

	private int useCount;

	private int remainCount;

	private String vacationType;

	private Long memberId;

}
``` 

- 이 엔티티는 명확한 정의가 더 필요할 것 같아 큰 수정은 안하였습니다. 

6. VacationRequest 
```java
@Entity
public class VacationRequest {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	@Column(name = "vacation_request_id")
	private Long id;

	@Column(name = "from_date", nullable = false)
	private LocalDateTime from;

	@Column(name = "to_date", nullable = false)
	private LocalDateTime to;

	private String reason;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "type_code", nullable = false)
	private Code type;

	@ManyToOne(fetch = FetchType.LAZY)
	@JoinColumn(name = "status_code", nullable = false)
	private Code status;

	@Version
	private Integer version;
}
``` 

- form , to 필드를 from_date , to_date 로 컬럼명을 변경하였습니다 . 
- from이 예약어이기 때문에 변경이 필요했습니다.
- type, status 연관관계를 추가하였습니다. 

7. Role enum 생성 (domain/member/enums/Role)

```java
public enum Role {
	USER, ADMIN
}
``` 
- adminYN으로 정의했지만, 추후 확장가능성과 security 에서 권한 설정을 위해 enum으로 변경하였습니다.

## 💬리뷰 요구사항(선택)
- Admin, Vacation 엔티티는 삭제하는게 맞겠죠? 
- 엔티티 변경 후 실행까지 해봤는데 문제 없었습니다. 
