### PR TITLE
feat: code crud 구현

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/config/CodeInitializationConfig.java
+++ b/backend/team6/src/main/java/programmers/team6/config/CodeInitializationConfig.java
@@ -1,0 +1,36 @@
+package programmers.team6.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import lombok.RequiredArgsConstructor;
+import programmers.team6.domain.member.enums.BasicCodeInfo;
+import programmers.team6.domain.member.repository.CodeRepository;
+import programmers.team6.domain.member.util.mapper.CodeMapper;
+
+@Configuration
+@RequiredArgsConstructor
+public class CodeInitializationConfig {
+	private final CodeRepository codeRepository;
+
+	/**
+	 * 현재 개발환경이고 다른 엔티티의 변수 수정 가능성이 있는 상황에서 우선적으로 CommandLineRunner를 활용하여 개발하였음, 그럼으로 yml의 profile은 dev로 작성 필요
+	 * 만약, 운영환경으로 넘어간다면 flyway로 수정하여 해당 부분또한 insert문이 포함된 sql 실행하도록 바꾸면 좋을듯
+	 * @return
+	 * @author gunwoong
+	 */
+	@Bean
+	@Profile("dev")
+	public CommandLineRunner initData() {
+		return args -> {
+			if (codeRepository.count() == 0) {  // 데이터베이스에 데이터가 없으면 삽입
+				for (int i = 0; i < BasicCodeInfo.values().length; i++) {
+					codeRepository.save(CodeMapper.toCode(BasicCodeInfo.values()[i]));
+				}
+			}
+		};
+	}
+
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/controller/CodeController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/controller/CodeController.java
@@ -1,0 +1,51 @@
+package programmers.team6.domain.member.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import programmers.team6.domain.member.dto.CodeCreateRequest;
+import programmers.team6.domain.member.dto.CodeReadResponse;
+import programmers.team6.domain.member.service.CodeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/code")
+public class CodeController {
+	private final CodeService codeService;
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	void registerCode(@RequestBody CodeCreateRequest codeCreateRequest) {
+		codeService.createCode(codeCreateRequest);
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	Page<CodeReadResponse> retrieveCodePage(@PageableDefault(page = 0, size = 20) Pageable pageable) {
+		return codeService.readCodePage(pageable);
+	}
+
+	@PutMapping("/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	void modifyCode(@PathVariable("id") Long id, @RequestBody CodeCreateRequest codeCreateRequest) {
+		codeService.updateCode(id, codeCreateRequest);
+	}
+
+	@DeleteMapping("/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	void deleteCode(@PathVariable("id") Long id) {
+		codeService.deleteCode(id);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/controller/CodeController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/controller/CodeController.java
@@ -21,7 +21,7 @@ import programmers.team6.domain.member.service.CodeService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/code")
+@RequestMapping("/admin/code")
 public class CodeController {
 	private final CodeService codeService;
 

--- a/backend/team6/src/main/java/programmers/team6/domain/member/dto/CodeCreateRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/dto/CodeCreateRequest.java
@@ -1,0 +1,4 @@
+package programmers.team6.domain.member.dto;
+
+public record CodeCreateRequest(String groupCode, String code, String name) {
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/dto/CodeReadResponse.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/dto/CodeReadResponse.java
@@ -1,0 +1,4 @@
+package programmers.team6.domain.member.dto;
+
+public record CodeReadResponse(Long id, String groupCode, String code, String name) {
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -44,4 +44,10 @@ public class Code extends BaseEntity {
 		this.code = code;
 		this.name = name;
 	}
+
+	public void updateCode(String groupCode, String code, String name) {
+		this.groupCode = groupCode;
+		this.code = code;
+		this.name = name;
+	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
@@ -24,7 +24,6 @@ import programmers.team6.global.entity.BaseEntity;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class Member extends BaseEntity {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/member/enums/BasicCodeInfo.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/enums/BasicCodeInfo.java
@@ -10,12 +10,12 @@ public enum BasicCodeInfo {
 	CONGRATULATORY("VACATION_TYPE", "04", "경조사 휴가");
 	private final String groupCode;
 	private final String code;
-	private final String description;
+	private final String name;
 
-	BasicCodeInfo(String groupCode, String code, String description) {
+	BasicCodeInfo(String groupCode, String code, String name) {
 		this.groupCode = groupCode;
 		this.code = code;
-		this.description = description;
+		this.name = name;
 	}
 
 	public static boolean isIn(String groupCode, String code) {

--- a/backend/team6/src/main/java/programmers/team6/domain/member/enums/BasicCodeInfo.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/enums/BasicCodeInfo.java
@@ -1,0 +1,30 @@
+package programmers.team6.domain.member.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum BasicCodeInfo {
+	ANNUAL("VACATION_TYPE", "01", "연차"),
+	REWARD("VACATION_TYPE", "02", "포상 휴가"),
+	OFFICIAL("VACATION_TYPE", "03", "공가"),
+	CONGRATULATORY("VACATION_TYPE", "04", "경조사 휴가");
+	private final String groupCode;
+	private final String code;
+	private final String description;
+
+	BasicCodeInfo(String groupCode, String code, String description) {
+		this.groupCode = groupCode;
+		this.code = code;
+		this.description = description;
+	}
+
+	public static boolean isIn(String groupCode, String code) {
+		for (BasicCodeInfo basicCodeInfo : values()) {
+			if (basicCodeInfo.getGroupCode() == groupCode && basicCodeInfo.getCode() == code) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+

--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/CodeRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/CodeRepository.java
@@ -2,12 +2,21 @@ package programmers.team6.domain.member.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import programmers.team6.domain.member.dto.CodeReadResponse;
 import programmers.team6.domain.member.entity.Code;
 
 public interface CodeRepository extends JpaRepository<Code, Long> {
 	Optional<Code> findByIdAndGroupCode(Long id, String groupCode);
 
 	Optional<Code> findByGroupCodeAndCode(String groupCode, String code);
+
+	@Query(value = "select new programmers.team6.domain.member.dto.CodeReadResponse(c.id,c.groupCode,c.code,c.name) "
+		+ "from Code c")
+	Page<CodeReadResponse> findCodePage(Pageable pageable);
+
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/service/CodeService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/service/CodeService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import programmers.team6.domain.member.dto.CodeCreateRequest;
 import programmers.team6.domain.member.dto.CodeReadResponse;
 import programmers.team6.domain.member.entity.Code;
+import programmers.team6.domain.member.enums.BasicCodeInfo;
 import programmers.team6.domain.member.enums.CodeExceptionMessage;
 import programmers.team6.domain.member.exception.CodeException;
 import programmers.team6.domain.member.repository.CodeRepository;
@@ -35,8 +36,17 @@ public class CodeService {
 		code.updateCode(codeCreateRequest.groupCode(), codeCreateRequest.code(), codeCreateRequest.name());
 	}
 
+	/**
+	 * 삭제하려는 code가 필수 CODE인 경우 삭제하지 못하도록 수정
+	 * @param id
+	 */
 	public void deleteCode(Long id) {
-		codeRepository.deleteById(id);
+		Code deletedTarget = codeRepository.findById(id)
+			.orElseThrow(() -> new CodeException(CodeExceptionMessage.EMPTY_CODE));
+		if (BasicCodeInfo.isIn(deletedTarget.getGroupCode(), deletedTarget.getCode())) {
+			return;
+		}
+		codeRepository.delete(deletedTarget);
 	}
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/service/CodeService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/service/CodeService.java
@@ -1,0 +1,42 @@
+package programmers.team6.domain.member.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import programmers.team6.domain.member.dto.CodeCreateRequest;
+import programmers.team6.domain.member.dto.CodeReadResponse;
+import programmers.team6.domain.member.entity.Code;
+import programmers.team6.domain.member.enums.CodeExceptionMessage;
+import programmers.team6.domain.member.exception.CodeException;
+import programmers.team6.domain.member.repository.CodeRepository;
+import programmers.team6.domain.member.util.mapper.CodeMapper;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CodeService {
+	private final CodeRepository codeRepository;
+
+	public void createCode(CodeCreateRequest codeCreateRequest) {
+		codeRepository.save(CodeMapper.toCode(codeCreateRequest));
+	}
+
+	@Transactional(readOnly = true)
+	public Page<CodeReadResponse> readCodePage(Pageable pageable) {
+		return codeRepository.findCodePage(pageable);
+	}
+
+	public void updateCode(Long id, CodeCreateRequest codeCreateRequest) {
+		Code code = codeRepository.findById(id).orElseThrow(() -> new CodeException(CodeExceptionMessage.EMPTY_CODE));
+
+		code.updateCode(codeCreateRequest.groupCode(), codeCreateRequest.code(), codeCreateRequest.name());
+	}
+
+	public void deleteCode(Long id) {
+		codeRepository.deleteById(id);
+	}
+
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
@@ -1,0 +1,16 @@
+package programmers.team6.domain.member.util.mapper;
+
+import lombok.experimental.UtilityClass;
+import programmers.team6.domain.member.dto.CodeCreateRequest;
+import programmers.team6.domain.member.entity.Code;
+
+@UtilityClass
+public class CodeMapper {
+	public static Code toCode(CodeCreateRequest codeCreateRequest) {
+		return Code.builder()
+			.groupCode(codeCreateRequest.groupCode())
+			.code(codeCreateRequest.code())
+			.name(codeCreateRequest.name())
+			.build();
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
@@ -19,7 +19,7 @@ public class CodeMapper {
 		return Code.builder()
 			.groupCode(basicCodeInfo.getGroupCode())
 			.code(basicCodeInfo.getCode())
-			.name(basicCodeInfo.name())
+			.name(basicCodeInfo.getName())
 			.build();
 	}
 

--- a/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/util/mapper/CodeMapper.java
@@ -3,6 +3,7 @@ package programmers.team6.domain.member.util.mapper;
 import lombok.experimental.UtilityClass;
 import programmers.team6.domain.member.dto.CodeCreateRequest;
 import programmers.team6.domain.member.entity.Code;
+import programmers.team6.domain.member.enums.BasicCodeInfo;
 
 @UtilityClass
 public class CodeMapper {
@@ -13,4 +14,13 @@ public class CodeMapper {
 			.name(codeCreateRequest.name())
 			.build();
 	}
+
+	public static Code toCode(BasicCodeInfo basicCodeInfo) {
+		return Code.builder()
+			.groupCode(basicCodeInfo.getGroupCode())
+			.code(basicCodeInfo.getCode())
+			.name(basicCodeInfo.name())
+			.build();
+	}
+
 }


### PR DESCRIPTION
제목: feat(32): code crud 기능

## #️⃣연관된 이슈 번호
- #32

## 📝작업 내용

리뷰가 끝난 후 추가한 부분은 아래와 같습니다.
**1. 기본 CODE(연차 등등)을 CommandLiner를 통해 생성**
**2. CODE 삭제 과정에서 삭제되면 안될것들(기본CODE)를 삭제 방지되도록**

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [X] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- CommandLiner 특성상 개발 환경에 적합하지, 운영환경에 적합하지 않음, 그럼으로 마이그레이션으로 작동하여 데이터 무결성을 지켜주는 Flyway를 사용해야 될것같음(운영환경에서)
- 지금 Flyway를 추가하지 않은 이유는 기본적으로 Flyway사용시 전체 엔티티 생성을 기존에는 ddl-auto를 통해 자동화해줬는데 이 부분이 막힘, 그래서 sql create문을 엔티티마다 작성해야 하는데 다른 엔티티들이 확정인지 불확실한 상황이어서 flyway를 추가하지 않았음
- 이후에 전체적으로 merge하고나서 생각해봐야할 문제라고 생각됩니다.
