### PR TITLE
feature(29) : 공통 예외처리

### DIFF
--- a/backend/team6/build.gradle
+++ b/backend/team6/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/config/JwtAuthenticationFilter.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/config/JwtAuthenticationFilter.java
@@ -30,8 +30,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
+		String uri = request.getRequestURI();
+		if (uri.startsWith("/auth")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		String token = jwtTokenProvider.extractToken(request);
-	
+
 		jwtTokenProvider.validate(token);
 
 		TokenBody tokenbody = jwtTokenProvider.parseClaims(token);

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/config/JwtAuthenticationFilter.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/config/JwtAuthenticationFilter.java
@@ -31,17 +31,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		FilterChain filterChain) throws ServletException, IOException {
 
 		String token = jwtTokenProvider.extractToken(request);
+	
+		jwtTokenProvider.validate(token);
 
-		if (token != null && jwtTokenProvider.validate(token)) {
+		TokenBody tokenbody = jwtTokenProvider.parseClaims(token);
 
-			TokenBody tokenbody = jwtTokenProvider.parseClaims(token);
+		Authentication auth = new UsernamePasswordAuthenticationToken(
+			tokenbody, null, List.of(new SimpleGrantedAuthority(tokenbody.role().toString()))
+		);
 
-			Authentication auth = new UsernamePasswordAuthenticationToken(
-				tokenbody, null, List.of(new SimpleGrantedAuthority(tokenbody.role().toString()))
-			);
+		SecurityContextHolder.getContext().setAuthentication(auth);
 
-			SecurityContextHolder.getContext().setAuthentication(auth);
-		}
 		filterChain.doFilter(request, response);
 	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
@@ -24,7 +24,6 @@ import programmers.team6.domain.auth.dto.request.RefreshTokenRequest;
 import programmers.team6.domain.auth.dto.response.AuthTokenResponse;
 import programmers.team6.domain.auth.dto.response.LoginResponse;
 import programmers.team6.domain.auth.service.AuthService;
-import programmers.team6.domain.auth.token.JwtTokenProvider;
 import programmers.team6.domain.auth.util.JwtUtils;
 
 @RestController
@@ -33,7 +32,6 @@ import programmers.team6.domain.auth.util.JwtUtils;
 public class AuthController {
 
 	private final AuthService authService;
-	private final JwtTokenProvider jwtTokenProvider;
 
 	@PostMapping("/signup")
 	public ResponseEntity<Void> signUp(@RequestBody MemberSignUpRequest memberSignUpRequest) {

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
@@ -1,9 +1,7 @@
 package programmers.team6.domain.auth.service;
 
 import java.util.Date;
-import java.util.NoSuchElementException;
 
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,14 +19,20 @@ import programmers.team6.domain.auth.util.JwtUtils;
 import programmers.team6.domain.member.entity.Code;
 import programmers.team6.domain.member.entity.Dept;
 import programmers.team6.domain.member.entity.Member;
-
 import programmers.team6.domain.member.enums.Role;
-
 import programmers.team6.domain.member.repository.CodeRepository;
 import programmers.team6.domain.member.repository.DeptRepository;
 import programmers.team6.domain.member.repository.MemberInfoRepository;
 import programmers.team6.domain.member.repository.MemberRepository;
 import programmers.team6.domain.member.util.mapper.MemberMapper;
+import programmers.team6.global.exception.code.ConflictErrorCode;
+import programmers.team6.global.exception.code.ForbiddenErrorCode;
+import programmers.team6.global.exception.code.NotFoundErrorCode;
+import programmers.team6.global.exception.code.UnauthorizedErrorCode;
+import programmers.team6.global.exception.customException.ConflictException;
+import programmers.team6.global.exception.customException.ForbiddenException;
+import programmers.team6.global.exception.customException.NotFoundException;
+import programmers.team6.global.exception.customException.UnauthorizedException;
 
 @Service
 @RequiredArgsConstructor
@@ -46,13 +50,17 @@ public class AuthService {
 	public void signUp(MemberSignUpRequest memberSignUpRequest) {
 
 		Dept dept = deptRepository.findById(memberSignUpRequest.dept()).orElseThrow(
-			() -> new IllegalArgumentException("해당 부서를 찾을 수 없습니다.")
+			() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_DEPT)
 		);
 
 		Code position = codeRepository.findByGroupCodeAndCode("POSITION", memberSignUpRequest.position())
 			.orElseThrow(
-				() -> new IllegalArgumentException("해당 직위를 찾을 수 없습니다.")
+				() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_POSITION)
 			);
+
+		if (isExistsByEmail(memberSignUpRequest.email())) {
+			throw new ConflictException(ConflictErrorCode.CONFLICT_EMAIL);
+		}
 
 		String encodedPassword = passwordEncoder.encode(memberSignUpRequest.password());
 
@@ -65,6 +73,10 @@ public class AuthService {
 
 	@Transactional(readOnly = true)
 	public boolean isEmailDuplicated(String email) {
+		return isExistsByEmail(email);
+	}
+
+	private boolean isExistsByEmail(String email) {
 		return memberInfoRepository.existsByEmail(email);
 	}
 
@@ -72,14 +84,14 @@ public class AuthService {
 	public LoginResponse login(MemberLoginRequest memberLoginRequest) {
 
 		Member member = memberRepository.findByEmail(memberLoginRequest.email())
-			.orElseThrow(() -> new NoSuchElementException("이메일 없음"));
+			.orElseThrow(() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_EMAIL));
 
 		if (member.getRole().equals(Role.PENDING)) {
-			throw new IllegalArgumentException("회원가입 승인 대기중입니다.");
+			throw new ForbiddenException(ForbiddenErrorCode.FORBIDDEN_PENDING);
 		}
 
 		if (!passwordEncoder.matches(memberLoginRequest.password(), member.getMemberInfo().getPassword())) {
-			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_PASSWORD);
 		}
 
 		TokenPairWithExpiration tokenPair = jwtTokenProvider.generateTokenPair(
@@ -93,14 +105,9 @@ public class AuthService {
 	}
 
 	public TokenPairWithExpiration reissue(String refreshToken) {
-		if (!jwtTokenProvider.validate(refreshToken)) {
-			//toDo exceptionhandler 처리
-			throw new BadCredentialsException("유효하지 않은 refresh 토큰");
-		}
+		jwtTokenProvider.validate(refreshToken);
 
-		if (jwtTokenProvider.isBlackListed(refreshToken)) {
-			throw new BadCredentialsException("블랙리스트에 등록된 토큰");
-		}
+		jwtTokenProvider.validateNotBlackListed(refreshToken);
 
 		TokenBody tokenBody = jwtTokenProvider.parseClaims(refreshToken);
 

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/token/JwtTokenProvider.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/token/JwtTokenProvider.java
@@ -23,6 +23,8 @@ import programmers.team6.domain.auth.dto.TokenBody;
 import programmers.team6.domain.auth.dto.TokenPairWithExpiration;
 import programmers.team6.domain.auth.service.JwtService;
 import programmers.team6.domain.member.enums.Role;
+import programmers.team6.global.exception.code.UnauthorizedErrorCode;
+import programmers.team6.global.exception.customException.UnauthorizedException;
 
 @Slf4j
 @Component
@@ -44,34 +46,31 @@ public class JwtTokenProvider {
 			jwtConfiguration.refreshTokenExpiration());
 	}
 
-	public boolean validate(String token) {
+	public void validate(String token) {
 		try {
 			Jws<Claims> claimsJws = Jwts.parser()
 				.verifyWith(getSecretKey())
 				.build()
 				.parseSignedClaims(token);
-
-			return true;
-		} catch (SecurityException | MalformedJwtException | SignatureException e) {
-			log.warn("유효하지 않은 JWT 서명: {}", e.getMessage());
+		} catch (SecurityException | SignatureException e) {
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_INVALID_SIGNATURE);
+		} catch (MalformedJwtException e) {
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_MALFORMED_TOKEN);
 		} catch (ExpiredJwtException e) {
-			log.warn("만료된 JWT: {}", e.getMessage());
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_EXPIRED_TOKEN);
 		} catch (UnsupportedJwtException e) {
-			log.warn("지원하지 않는 JWT 형식: {}", e.getMessage());
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_UNSUPPORTED_TOKEN);
 		} catch (IllegalArgumentException e) {
-			log.warn("잘못된 JWT 입력값: {}", e.getMessage());
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_ILLEGAL_ARGUMENT_TOKEN);
+		} catch (Exception e) {
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_INVALID_TOKEN);
 		}
-		return false;
 	}
 
-	public boolean isBlackListed(String accessToken) {
-
-		if (jwtService.isBlackListed(accessToken)) {
-			log.warn(" 블랙리스트 토큰 접근 시도: {}", accessToken);
-			return true;
+	public void validateNotBlackListed(String refreshToken) {
+		if (jwtService.isBlackListed(refreshToken)) {
+			throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_BLACKLIST_TOKEN);
 		}
-
-		return false;
 	}
 
 	public TokenBody parseClaims(String token) {
@@ -120,9 +119,10 @@ public class JwtTokenProvider {
 		String header = request.getHeader(HEADER);
 
 		if (header != null && header.startsWith(BEARER)) {
-			return header.substring(7);
+			return header.substring(BEARER.length());
 		}
-		return null;
+		throw new UnauthorizedException(UnauthorizedErrorCode.UNAUTHORIZED_INVALID_HEADER);
+
 	}
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -22,7 +22,6 @@ import programmers.team6.global.entity.BaseEntity;
 		@UniqueConstraint(columnNames = {"group_code", "code"})
 	}
 )
-@Getter
 public class Code extends BaseEntity {
 
 	@Id

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package programmers.team6.domain.member.entity;
 
 import java.time.LocalDateTime;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,7 +25,6 @@ import programmers.team6.global.entity.BaseEntity;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class Member extends BaseEntity {
 
 	@Id
@@ -35,11 +35,11 @@ public class Member extends BaseEntity {
 	@Column(nullable = false)
 	private String name;
 
-	@ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "dept_id")
 	private Dept dept;
 
-	@ManyToOne(fetch = FetchType.LAZY,cascade = CascadeType.PERSIST)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "position_id")
 	private Code position;
 

--- a/backend/team6/src/main/java/programmers/team6/global/exception/ErrorStatus.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/ErrorStatus.java
@@ -1,0 +1,9 @@
+package programmers.team6.global.exception;
+
+public enum ErrorStatus {
+	BAD_REQUEST,
+	UNAUTHORIZED,
+	FORBIDDEN,
+	NOT_FOUND,
+	CONFLICT
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/GlobalExceptionHandler.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package programmers.team6.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import programmers.team6.global.exception.code.ErrorCode;
+import programmers.team6.global.exception.customException.ConflictException;
+import programmers.team6.global.exception.customException.ForbiddenException;
+import programmers.team6.global.exception.customException.NotFoundException;
+import programmers.team6.global.exception.customException.UnauthorizedException;
+import programmers.team6.global.exception.response.ErrorResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(NotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+		ErrorCode errorCode = e.getErrorCode();
+
+		log.warn(errorCode.getMessage());
+
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
+				errorCode.getHttpStatus().value()));
+	}
+
+	@ExceptionHandler(ConflictException.class)
+	public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
+		ErrorCode errorCode = e.getErrorCode();
+
+		log.warn(errorCode.getMessage());
+
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
+				errorCode.getHttpStatus().value()));
+	}
+
+	@ExceptionHandler(ForbiddenException.class)
+	public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+		ErrorCode errorCode = e.getErrorCode();
+
+		log.warn(errorCode.getMessage());
+
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
+				errorCode.getHttpStatus().value()));
+	}
+
+	@ExceptionHandler(UnauthorizedException.class)
+	public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+		ErrorCode errorCode = e.getErrorCode();
+
+		log.warn(errorCode.getMessage());
+
+		return ResponseEntity.status(errorCode.getHttpStatus())
+			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
+				errorCode.getHttpStatus().value()));
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/GlobalExceptionHandler.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/GlobalExceptionHandler.java
@@ -6,57 +6,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
 import programmers.team6.global.exception.code.ErrorCode;
-import programmers.team6.global.exception.customException.ConflictException;
-import programmers.team6.global.exception.customException.ForbiddenException;
-import programmers.team6.global.exception.customException.NotFoundException;
-import programmers.team6.global.exception.customException.UnauthorizedException;
+import programmers.team6.global.exception.customException.CustomException;
 import programmers.team6.global.exception.response.ErrorResponse;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(NotFoundException.class)
-	public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundException(CustomException e) {
 		ErrorCode errorCode = e.getErrorCode();
 
 		log.warn(errorCode.getMessage());
 
 		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
-				errorCode.getHttpStatus().value()));
+			.body(new ErrorResponse(errorCode.toString(), errorCode.getMessage(),
+				errorCode.getHttpStatusCode()));
 	}
 
-	@ExceptionHandler(ConflictException.class)
-	public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
-		ErrorCode errorCode = e.getErrorCode();
-
-		log.warn(errorCode.getMessage());
-
-		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
-				errorCode.getHttpStatus().value()));
-	}
-
-	@ExceptionHandler(ForbiddenException.class)
-	public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
-		ErrorCode errorCode = e.getErrorCode();
-
-		log.warn(errorCode.getMessage());
-
-		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
-				errorCode.getHttpStatus().value()));
-	}
-
-	@ExceptionHandler(UnauthorizedException.class)
-	public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
-		ErrorCode errorCode = e.getErrorCode();
-
-		log.warn(errorCode.getMessage());
-
-		return ResponseEntity.status(errorCode.getHttpStatus())
-			.body(new ErrorResponse(errorCode.getClass().getSimpleName(), errorCode.getMessage(),
-				errorCode.getHttpStatus().value()));
-	}
 }

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ConflictErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ConflictErrorCode.java
@@ -9,6 +9,7 @@ public enum ConflictErrorCode implements ErrorCode {
 	CONFLICT_EMAIL("중복된 이메일입니다.");
 
 	private final String message;
+	private final HttpStatus httpStatus = HttpStatus.CONFLICT;
 
 	ConflictErrorCode(String message) {
 		this.message = message;
@@ -21,11 +22,17 @@ public enum ConflictErrorCode implements ErrorCode {
 
 	@Override
 	public HttpStatus getHttpStatus() {
-		return HttpStatus.CONFLICT;
+		return httpStatus;
+	}
+
+	@Override
+	public int getHttpStatusCode() {
+		return httpStatus.value();
 	}
 
 	@Override
 	public String getMessage() {
 		return message;
 	}
+
 }

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ConflictErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ConflictErrorCode.java
@@ -1,0 +1,31 @@
+package programmers.team6.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import programmers.team6.global.exception.ErrorStatus;
+
+public enum ConflictErrorCode implements ErrorCode {
+
+	CONFLICT_EMAIL("중복된 이메일입니다.");
+
+	private final String message;
+
+	ConflictErrorCode(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public ErrorStatus getErrorStatus() {
+		return ErrorStatus.CONFLICT;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.CONFLICT;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ErrorCode.java
@@ -9,5 +9,7 @@ public interface ErrorCode {
 
 	HttpStatus getHttpStatus();
 
+	int getHttpStatusCode();
+
 	String getMessage();
 }

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ErrorCode.java
@@ -1,0 +1,13 @@
+package programmers.team6.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import programmers.team6.global.exception.ErrorStatus;
+
+public interface ErrorCode {
+	ErrorStatus getErrorStatus();
+
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ForbiddenErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ForbiddenErrorCode.java
@@ -9,6 +9,7 @@ public enum ForbiddenErrorCode implements ErrorCode {
 	FORBIDDEN_PENDING("회원가입 승인 대기중입니다");
 
 	private final String message;
+	private final HttpStatus httpStatus = HttpStatus.FORBIDDEN;
 
 	ForbiddenErrorCode(String message) {
 		this.message = message;
@@ -21,11 +22,17 @@ public enum ForbiddenErrorCode implements ErrorCode {
 
 	@Override
 	public HttpStatus getHttpStatus() {
-		return HttpStatus.FORBIDDEN;
+		return httpStatus;
+	}
+
+	@Override
+	public int getHttpStatusCode() {
+		return httpStatus.value();
 	}
 
 	@Override
 	public String getMessage() {
 		return message;
 	}
+
 }

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/ForbiddenErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/ForbiddenErrorCode.java
@@ -1,0 +1,31 @@
+package programmers.team6.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import programmers.team6.global.exception.ErrorStatus;
+
+public enum ForbiddenErrorCode implements ErrorCode {
+
+	FORBIDDEN_PENDING("회원가입 승인 대기중입니다");
+
+	private final String message;
+
+	ForbiddenErrorCode(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public ErrorStatus getErrorStatus() {
+		return ErrorStatus.FORBIDDEN;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.FORBIDDEN;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
@@ -1,0 +1,33 @@
+package programmers.team6.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import programmers.team6.global.exception.ErrorStatus;
+
+public enum NotFoundErrorCode implements ErrorCode {
+
+	NOT_FOUND_DEPT("부서 정보를 찾을 수 없습니다."),
+	NOT_FOUND_POSITION("직위 정보를 찾을 수 없습니다."),
+	NOT_FOUND_EMAIL("이메일 정보를 찾을 수 없습니다.");
+
+	private final String message;
+
+	NotFoundErrorCode(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public ErrorStatus getErrorStatus() {
+		return ErrorStatus.NOT_FOUND;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.NOT_FOUND;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
@@ -11,6 +11,7 @@ public enum NotFoundErrorCode implements ErrorCode {
 	NOT_FOUND_EMAIL("이메일 정보를 찾을 수 없습니다.");
 
 	private final String message;
+	private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
 
 	NotFoundErrorCode(String message) {
 		this.message = message;
@@ -23,7 +24,12 @@ public enum NotFoundErrorCode implements ErrorCode {
 
 	@Override
 	public HttpStatus getHttpStatus() {
-		return HttpStatus.NOT_FOUND;
+		return httpStatus;
+	}
+
+	@Override
+	public int getHttpStatusCode() {
+		return httpStatus.value();
 	}
 
 	@Override

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/UnauthorizedErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/UnauthorizedErrorCode.java
@@ -17,6 +17,7 @@ public enum UnauthorizedErrorCode implements ErrorCode {
 	UNAUTHORIZED_EXPIRED_TOKEN("만료된 토큰입니다.");
 
 	private final String message;
+	private final HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
 
 	UnauthorizedErrorCode(String message) {
 		this.message = message;
@@ -29,7 +30,12 @@ public enum UnauthorizedErrorCode implements ErrorCode {
 
 	@Override
 	public HttpStatus getHttpStatus() {
-		return HttpStatus.UNAUTHORIZED;
+		return httpStatus;
+	}
+
+	@Override
+	public int getHttpStatusCode() {
+		return httpStatus.value();
 	}
 
 	@Override

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/UnauthorizedErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/UnauthorizedErrorCode.java
@@ -1,0 +1,39 @@
+package programmers.team6.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import programmers.team6.global.exception.ErrorStatus;
+
+public enum UnauthorizedErrorCode implements ErrorCode {
+
+	UNAUTHORIZED_PASSWORD("비밀번호가 일치하지 않습니다"),
+	UNAUTHORIZED_INVALID_TOKEN("유효하지 않은 토큰입니다."),
+	UNAUTHORIZED_BLACKLIST_TOKEN("블랙리스트에 등록된 토큰입니다."),
+	UNAUTHORIZED_INVALID_SIGNATURE("서명이 유효하지 않습니다."),
+	UNAUTHORIZED_MALFORMED_TOKEN("구조가 잘못된 JWT 입니다."),
+	UNAUTHORIZED_ILLEGAL_ARGUMENT_TOKEN("비어있거나 잘못된 JWT 입니다."),
+	UNAUTHORIZED_UNSUPPORTED_TOKEN("지원하지 않는 토큰 형식입니다."),
+	UNAUTHORIZED_INVALID_HEADER("요청 헤더가 유효하지 않습니다."),
+	UNAUTHORIZED_EXPIRED_TOKEN("만료된 토큰입니다.");
+
+	private final String message;
+
+	UnauthorizedErrorCode(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public ErrorStatus getErrorStatus() {
+		return ErrorStatus.UNAUTHORIZED;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.UNAUTHORIZED;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/BadRequestException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/BadRequestException.java
@@ -1,0 +1,10 @@
+package programmers.team6.global.exception.customException;
+
+import programmers.team6.global.exception.code.ErrorCode;
+
+public class BadRequestException extends CustomException {
+
+	public BadRequestException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/ConflictException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/ConflictException.java
@@ -1,0 +1,10 @@
+package programmers.team6.global.exception.customException;
+
+import programmers.team6.global.exception.code.ErrorCode;
+
+public class ConflictException extends CustomException {
+
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/CustomException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/CustomException.java
@@ -1,0 +1,15 @@
+package programmers.team6.global.exception.customException;
+
+import lombok.Getter;
+import programmers.team6.global.exception.code.ErrorCode;
+
+@Getter
+public abstract class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/ForbiddenException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/ForbiddenException.java
@@ -1,0 +1,10 @@
+package programmers.team6.global.exception.customException;
+
+import programmers.team6.global.exception.code.ErrorCode;
+
+public class ForbiddenException extends CustomException {
+
+	public ForbiddenException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/NotFoundException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/NotFoundException.java
@@ -1,0 +1,10 @@
+package programmers.team6.global.exception.customException;
+
+import programmers.team6.global.exception.code.NotFoundErrorCode;
+
+public class NotFoundException extends CustomException {
+
+	public NotFoundException(NotFoundErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/UnauthorizedException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package programmers.team6.global.exception.customException;
+
+import programmers.team6.global.exception.code.ErrorCode;
+
+public class UnauthorizedException extends CustomException {
+
+	public UnauthorizedException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/response/ErrorResponse.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/response/ErrorResponse.java
@@ -1,0 +1,14 @@
+package programmers.team6.global.exception.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+	private final String codeName;
+	private final String message;
+	private final int status;
+
+}

--- a/backend/team6/src/test/java/programmers/team6/domain/auth/service/AuthServiceTests.java
+++ b/backend/team6/src/test/java/programmers/team6/domain/auth/service/AuthServiceTests.java
@@ -1,6 +1,7 @@
 package programmers.team6.domain.auth.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -38,6 +39,8 @@ import programmers.team6.domain.member.repository.CodeRepository;
 import programmers.team6.domain.member.repository.DeptRepository;
 import programmers.team6.domain.member.repository.MemberInfoRepository;
 import programmers.team6.domain.member.repository.MemberRepository;
+import programmers.team6.global.exception.code.NotFoundErrorCode;
+import programmers.team6.global.exception.customException.NotFoundException;
 
 @Transactional
 @SpringBootTest
@@ -87,40 +90,83 @@ public class AuthServiceTests {
 
 	}
 
+	@Test
+	@DisplayName("회원가입 성공 테스트")
+	void signUpSuccessTest() throws Exception {
+		MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
+			"홍길동",
+			"hong@naver.com",
+			1L,
+			"01",
+			LocalDateTime.now(),
+			"1990-01-01",
+			"password1234");
+
+		authService.signUp(memberSignUpRequest);
+
+		Member savedMember = memberRepository.findByEmail("hong@naver.com")
+			.orElseThrow(() -> new RuntimeException("회원 저장 실패 "));
+
+		assertThat(savedMember.getName()).isEqualTo(memberSignUpRequest.name());
+		assertThat(savedMember.getDept().getId()).isEqualTo(memberSignUpRequest.dept());
+		assertThat(savedMember.getPosition().getCode()).isEqualTo(memberSignUpRequest.position());
+		assertThat(savedMember.getJoinDate()).isEqualTo(memberSignUpRequest.joinDate());
+
+		MemberInfo savedMemberInfo = memberInfoRepository.findById(savedMember.getId())
+			.orElseThrow(() -> new RuntimeException("회원 저장 실패 "));
+
+		assertThat(savedMemberInfo.getBirth()).isEqualTo(memberSignUpRequest.birth());
+		assertThat(savedMemberInfo.getEmail()).isEqualTo(memberSignUpRequest.email());
+		assertThat(
+			passwordEncoder.matches(memberSignUpRequest.password(), savedMemberInfo.getPassword())).isTrue();
+	}
+
 	@Nested
-	@DisplayName("회원가입 테스트")
-	class signUpTests {
+	@DisplayName("회원가입 실패 테스트")
+	class signUpFailTests {
 
 		@Test
-		@DisplayName("회원가입 성공 테스트")
-		void signUpSuccessTest() throws Exception {
+		@DisplayName("not found- dept")
+		void NotFoundDeptTest() throws Exception {
+
+			Long invalidDeptId = -99L;
+
 			MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
 				"홍길동",
 				"hong@naver.com",
-				1L,
+				invalidDeptId,
 				"01",
 				LocalDateTime.now(),
 				"1990-01-01",
 				"password1234");
 
-			authService.signUp(memberSignUpRequest);
+			NotFoundException notFoundException = assertThrows(NotFoundException.class,
+				() -> authService.signUp(memberSignUpRequest));
 
-			Member savedMember = memberRepository.findByEmail("hong@naver.com")
-				.orElseThrow(() -> new RuntimeException("회원 저장 실패 "));
-
-			assertThat(savedMember.getName()).isEqualTo(memberSignUpRequest.name());
-			assertThat(savedMember.getDept().getId()).isEqualTo(memberSignUpRequest.dept());
-			assertThat(savedMember.getPosition().getCode()).isEqualTo(memberSignUpRequest.position());
-			assertThat(savedMember.getJoinDate()).isEqualTo(memberSignUpRequest.joinDate());
-
-			MemberInfo savedMemberInfo = memberInfoRepository.findById(savedMember.getId())
-				.orElseThrow(() -> new RuntimeException("회원 저장 실패 "));
-
-			assertThat(savedMemberInfo.getBirth()).isEqualTo(memberSignUpRequest.birth());
-			assertThat(savedMemberInfo.getEmail()).isEqualTo(memberSignUpRequest.email());
-			assertThat(
-				passwordEncoder.matches(memberSignUpRequest.password(), savedMemberInfo.getPassword())).isTrue();
+			assertThat(notFoundException.getErrorCode()).isEqualTo(NotFoundErrorCode.NOT_FOUND_DEPT);
 		}
+
+		@Test
+		@DisplayName("not found- position")
+		void NotFoundPositionTest() throws Exception {
+
+			String invalidPosition = "invalidPosition";
+
+			MemberSignUpRequest memberSignUpRequest = new MemberSignUpRequest(
+				"홍길동",
+				"hong@naver.com",
+				1L,
+				invalidPosition,
+				LocalDateTime.now(),
+				"1990-01-01",
+				"password1234");
+
+			NotFoundException notFoundException = assertThrows(NotFoundException.class,
+				() -> authService.signUp(memberSignUpRequest));
+
+			assertThat(notFoundException.getErrorCode()).isEqualTo(NotFoundErrorCode.NOT_FOUND_POSITION);
+		}
+
 	}
 
 	@Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #29 

## 📝작업 내용
1. errorStatus 정의
- erorrCode의 대분류를 정의했습니다. 
```java
public enum ErrorStatus {
	BAD_REQUEST,
	UNAUTHORIZED,
	FORBIDDEN,
	NOT_FOUND,
	CONFLICT
}
``` 
2. errorCode 
- errorCode를 비즈니스 상황별로 만들기엔 클래스가 많아질 것 같아서 errorStatus 종류별로 만들었습니다.
- ErrorCode interface를 만들고 
- 이 interface 를 implements하는 클래스를 만들었습니다
- ConflictErrorCode , ForbliddenErrorCode, NotFoundErrorCode, UnauthorizedErrorcode 
```java
public interface ErrorCode {
	ErrorStatus getErrorStatus();

	HttpStatus getHttpStatus();

	String getMessage();
}
``` 
3. ErrorCode 구현 
- ErrorStatus,HttpStatus 를 enum안에 강제하였습니다. 
- 메세지로만 생성할 수 있게 구현하였습니다. 
```java
public enum NotFoundErrorCode implements ErrorCode {

	NOT_FOUND_DEPT("부서 정보를 찾을 수 없습니다."),
	NOT_FOUND_POSITION("직위 정보를 찾을 수 없습니다."),
	NOT_FOUND_EMAIL("이메일 정보를 찾을 수 없습니다.");

	private final String message;

	NotFoundErrorCode(String message) {
		this.message = message;
	}

	@Override
	public ErrorStatus getErrorStatus() {
		return ErrorStatus.NOT_FOUND;
	}

	@Override
	public HttpStatus getHttpStatus() {
		return HttpStatus.NOT_FOUND;
	}

	@Override
	public String getMessage() {
		return message;
	}
}
``` 

4. Exception 정의 
- 마찬가지로 errorStatus 별로 정의하기 위해 abstract class를 생성하였습니다.
```java
@Getter
public abstract class CustomException extends RuntimeException {

	private final ErrorCode errorCode;

	public CustomException(ErrorCode errorCode) {
		super(errorCode.getMessage());
		this.errorCode = errorCode;
	}
}
``` 

5. Exception 구현
- 파라미터를 NotFoundErrorcode로 받아서 생성하게 만듬 
```java
public class NotFoundException extends CustomException {

	public NotFoundException(NotFoundErrorCode errorCode) {
		super(errorCode);
	}
}
``` 

6. ErrorResponse 정의
```java
@Getter
@AllArgsConstructor
public class ErrorResponse {

	private final String codeName;
	private final String message;
	private final int status;

}
``` 
7. globalHandler 구현
- 예외별로 처리하는 로직이 현재는 같음
- 비즈니스 로직 별로 처리해야하는 로직이 다를 것으로 예상되어 공통으로 묶지않음
-  errorCode.getErrorSatus()를 switch 문으로 나눠서 구현해야할것으로 예상됨
-> 공통 구현으로 수정함 

8.적용
- 상황에 맞는 errorCode 생성 , errorException을 생성하여 적용해줌
```java
@Transactional
	public void signUp(MemberSignUpRequest memberSignUpRequest) {

		Dept dept = deptRepository.findById(memberSignUpRequest.dept()).orElseThrow(
			() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_DEPT)
		);
``` 

에러 응답은 아래와 같이 나옴 
<img width="428" alt="image" src="https://github.com/user-attachments/assets/a6339671-1b1e-492f-9a7b-45427acde2f9" />


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- errorResponse 를 임의로 설정하긴했는데 예외 응답 로직에서 필요한 부분이 있으시면 추가하셔도 될 것 같습니다.
- 예외처리도 처음해본거라 .. 의견 마구마구 주십쇼 
