### PR TITLE
fix(49): code getter 중복 및 code vacation to vacationType 수정

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/admin/service/AdminService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/service/AdminService.java
@@ -56,9 +56,8 @@ public class AdminService {
 		VacationRequest vacationRequest = vacationRequestRepository.findVacationRequestById(id)
 			.orElseThrow(() -> new VacationException(VacationExceptionMessage.EMPTY_VACATION_REQUEST_DETAIL));
 
-		// TODO - should change, hard coding "VACATION"
 		Code vacationRequestType = codeRepository.findByIdAndGroupCode(vacationRequestDetailUpdateRequest.typeId(),
-			"VACATION").orElseThrow(() -> new CodeException(CodeExceptionMessage.EMPTY_CODE));
+			"VACATION_TYPE").orElseThrow(() -> new CodeException(CodeExceptionMessage.EMPTY_CODE));
 		vacationRequest.update(vacationRequestType, vacationRequestDetailUpdateRequest.from(),
 			vacationRequestDetailUpdateRequest.to(), vacationRequestDetailUpdateRequest.vacationRequestStatus(),
 			vacationRequestDetailUpdateRequest.reason());

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Code.java
@@ -22,7 +22,6 @@ import programmers.team6.global.entity.BaseEntity;
 		@UniqueConstraint(columnNames = {"group_code", "code"})
 	}
 )
-@Getter
 public class Code extends BaseEntity {
 
 	@Id


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #49 

## 📝작업 내용
- code 테이블의 getter 제거 및 다른 부분에서 코드의 그룹코드를 VACATION으로 사용하는 걸 VACATION_TYPE로 즉 코드 명세서와 동일하게 수정하였음