### PR TITLE
refactor(48): security 기본계정 로그 지우기

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/Team6Application.java
+++ b/backend/team6/src/main/java/programmers/team6/Team6Application.java
@@ -2,13 +2,14 @@ package programmers.team6;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import programmers.team6.domain.auth.config.JwtConfiguration;
 
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 @EnableConfigurationProperties(JwtConfiguration.class)
 public class Team6Application {
 

--- a/backend/team6/src/main/java/programmers/team6/global/config/SecurityConfig.java
+++ b/backend/team6/src/main/java/programmers/team6/global/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain securityFilterchain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
 			.httpBasic(httpB -> httpB.disable())
 			.formLogin(form -> form.disable())


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #48 

## 📝작업 내용
- securityFilterChain 메소드 명 c->C 
- @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class}) 옵션 추가 
- security 기본계정 생성 off 



## 💬리뷰 요구사항(선택)

