### PR TITLE
fix(69): token 재발급시 유효기간 설정 변경

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController {
 	@GetMapping("/email-duplicate-check")
 	public ResponseEntity<Map<String, Boolean>> isEmailDuplicated(@RequestParam String email) {
 
-		boolean isEmailDuplicated = authService.isEmailDuplicated(email);
+		boolean isEmailDuplicated = authService.isExistsByEmail(email);
 
 		return ResponseEntity.ok(Map.of("isEmailDuplicated", isEmailDuplicated));
 	}

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
@@ -13,14 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.cors.PreFlightRequestHandler;
 
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import programmers.team6.domain.auth.dto.TokenPairWithExpiration;
 import programmers.team6.domain.auth.dto.request.MemberLoginRequest;
 import programmers.team6.domain.auth.dto.request.MemberSignUpRequest;
-import programmers.team6.domain.auth.dto.request.RefreshTokenRequest;
+import programmers.team6.domain.auth.dto.response.AccessTokenResponse;
 import programmers.team6.domain.auth.dto.response.AuthTokenResponse;
 import programmers.team6.domain.auth.dto.response.LoginResponse;
 import programmers.team6.domain.auth.service.AuthService;
@@ -32,6 +32,7 @@ import programmers.team6.domain.auth.util.JwtUtils;
 public class AuthController {
 
 	private final AuthService authService;
+	private final PreFlightRequestHandler preFlightRequestHandler;
 
 	@PostMapping("/signup")
 	public ResponseEntity<Void> signUp(@RequestBody MemberSignUpRequest memberSignUpRequest) {
@@ -57,27 +58,21 @@ public class AuthController {
 
 		String refreshToken = loginResponse.refreshToken();
 
-		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
-			.httpOnly(true)
-			.secure(true)
-			.path("/")
-			.sameSite("Strict")
-			.maxAge(JwtUtils.calculateTtlMillis(loginResponse.refreshTokenExpiresIn()))
-			.build();
-
-		response.setHeader("Set-Cookie", refreshCookie.toString());
+		JwtUtils.addRefreshTokenCookie(response, refreshToken, loginResponse.refreshTokenExpiresIn());
 
 		return ResponseEntity.ok(Map.of("token", loginResponse.authTokenResponse()));
 	}
 
 	@PostMapping("/reissue")
-	public ResponseEntity<TokenPairWithExpiration> refresh(
-		@RequestBody @Valid RefreshTokenRequest refreshTokenRequest) {
-		String refreshToken = refreshTokenRequest.refreshToken();
+	public ResponseEntity<AccessTokenResponse> refresh(
+		@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
 
 		TokenPairWithExpiration tokenPair = authService.reissue(refreshToken);
 
-		return ResponseEntity.ok(tokenPair);
+		JwtUtils.addRefreshTokenCookie(response, tokenPair.refreshToken(), tokenPair.refreshTokenExpiresIn());
+
+		return ResponseEntity.ok(
+			new AccessTokenResponse(tokenPair.accessToken(), JwtUtils.toSeconds(tokenPair.accessTokenExpiresIn())));
 	}
 
 	@PostMapping("/logout")

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/controller/AuthController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.cors.PreFlightRequestHandler;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +31,6 @@ import programmers.team6.domain.auth.util.JwtUtils;
 public class AuthController {
 
 	private final AuthService authService;
-	private final PreFlightRequestHandler preFlightRequestHandler;
 
 	@PostMapping("/signup")
 	public ResponseEntity<Void> signUp(@RequestBody MemberSignUpRequest memberSignUpRequest) {

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,9 +1,0 @@
-package programmers.team6.domain.auth.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record RefreshTokenRequest(
-	@NotBlank(message = "refreshToken은 필수입니다.")
-	String refreshToken
-) {
-}

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/dto/response/AccessTokenResponse.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,7 @@
+package programmers.team6.domain.auth.dto.response;
+
+public record AccessTokenResponse(
+	String accessToken,
+	long accessTokenExpiresIn
+) {
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
@@ -35,6 +35,7 @@ import programmers.team6.global.exception.customException.NotFoundException;
 import programmers.team6.global.exception.customException.UnauthorizedException;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -46,7 +47,6 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtService jwtService;
 
-	@Transactional
 	public void signUp(MemberSignUpRequest memberSignUpRequest) {
 
 		Dept dept = deptRepository.findById(memberSignUpRequest.dept()).orElseThrow(
@@ -72,15 +72,11 @@ public class AuthService {
 	}
 
 	@Transactional(readOnly = true)
-	public boolean isEmailDuplicated(String email) {
-		return isExistsByEmail(email);
-	}
-
-	private boolean isExistsByEmail(String email) {
+	public boolean isExistsByEmail(String email) {
 		return memberInfoRepository.existsByEmail(email);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public LoginResponse login(MemberLoginRequest memberLoginRequest) {
 
 		Member member = memberRepository.findByEmail(memberLoginRequest.email())

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/service/AuthService.java
@@ -109,6 +109,8 @@ public class AuthService {
 
 		jwtTokenProvider.validateNotBlackListed(refreshToken);
 
+		addBlackList(refreshToken);
+
 		TokenBody tokenBody = jwtTokenProvider.parseClaims(refreshToken);
 
 		return jwtTokenProvider.generateTokenPair(

--- a/backend/team6/src/main/java/programmers/team6/domain/auth/util/JwtUtils.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/util/JwtUtils.java
@@ -2,14 +2,31 @@ package programmers.team6.domain.auth.util;
 
 import java.util.Date;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+import jakarta.servlet.http.HttpServletResponse;
+
 public class JwtUtils {
 
-	public static long calculateTtlMillis(long expiration) {
-		return Math.max(expiration - System.currentTimeMillis(), 0);
+	public static long toSeconds(long millis) {
+		return millis / 1000;
 	}
 
 	public static long calculateTtlMillis(Date expiration) {
 		return Math.max(expiration.getTime() - System.currentTimeMillis(), 0);
+	}
+
+	public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken, long expiresIn) {
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.path("/")
+			.sameSite("Strict")
+			.maxAge(JwtUtils.toSeconds(expiresIn))
+			.build();
+
+		response.setHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 	}
 
 }


### PR DESCRIPTION

close #69  

## #️⃣연관된 이슈 번호
- #69 

## 📝작업 내용
- refresh token 설정 시 유효기간을 duration/1000이 아닌 duration.현재시간-현재시간으로 내려주고있었음
- maxAge가 0으로 생성되어 브라우저에서 쓸 수 없는 토큰이 전송되고있었음 
- reissue(재발급) 시 pair 토큰을 생성해주지만 기존 refresh token을 블랙리스트에 저장하는 로직이 없었음(로직 추가) 
- 재발급시 컨트롤러에서 새로 발급 받은 refresh 토큰을 쿠키에 set 해주는 부분이 없어서 추가함 


## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- issue 는 fix 로 올리고 작업 브랜치는 feat으로 생성했네요 .. 죄송합니다.. 🥲
