### PR TITLE
refactor(72) : 2차 결재자 지정

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
@@ -25,10 +25,6 @@ public class Dept extends BaseEntity {
 	@Column(nullable = false)
 	private String deptName;
 
-	public void setDeptLeader(Member deptLeader) {
-		this.deptLeader = deptLeader;
-	}
-
 	@OneToOne
 	@JoinColumn(name = "dept_leader_id")
 	private Member deptLeader;
@@ -38,4 +34,5 @@ public class Dept extends BaseEntity {
 		this.deptName = deptName;
 		this.deptLeader = deptLeader;
 	}
+
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/entity/Dept.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import programmers.team6.global.entity.BaseEntity;
+import programmers.team6.global.exception.code.NotFoundErrorCode;
+import programmers.team6.global.exception.customException.NotFoundException;
 
 @Getter
 @Entity
@@ -33,6 +35,13 @@ public class Dept extends BaseEntity {
 	public Dept(String deptName, Member deptLeader) {
 		this.deptName = deptName;
 		this.deptLeader = deptLeader;
+	}
+
+	public Member getDeptLeader() {
+		if (this.deptLeader == null) {
+			throw new NotFoundException(NotFoundErrorCode.NOT_FOUND_DEPT_LEADER);
+		}
+		return this.deptLeader;
 	}
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/DeptRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/DeptRepository.java
@@ -1,8 +1,11 @@
 package programmers.team6.domain.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import programmers.team6.domain.member.entity.Dept;
 
 public interface DeptRepository extends JpaRepository<Dept, Long> {
+	Optional<Dept> findByDeptName(String deptName);
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/service/ApprovalStepService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/service/ApprovalStepService.java
@@ -9,7 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import programmers.team6.domain.member.entity.Dept;
 import programmers.team6.domain.member.entity.Member;
+import programmers.team6.domain.member.repository.DeptRepository;
 import programmers.team6.domain.member.repository.MemberRepository;
 import programmers.team6.domain.vacation.dto.ApprovalFirstStepDetailResponse;
 import programmers.team6.domain.vacation.dto.ApprovalFirstStepSelectResponse;
@@ -38,6 +40,7 @@ public class ApprovalStepService {
 	private final ApprovalStepRepository approvalStepRepository;
 	private final MemberRepository memberRepository;
 	private final VacationInfoRepository vacationInfoRepository;
+	private final DeptRepository deptRepository;
 
 	public Page<ApprovalFirstStepSelectResponse> findFirstStepByMemberId(Long memberId, Pageable pageable) {
 		return approvalStepRepository.findFirstStepByMemberId(memberId, STEP1, pageable);
@@ -155,14 +158,12 @@ public class ApprovalStepService {
 	}
 
 	// 휴가 신청 시 호출되어, 해당 멤버의 결재 단계 생성
-	public void saveApprovalStep(Long firstApproverId, Long secondApproverId, VacationRequest vacationRequest) {
-		Member findFirstMember = memberRepository.findById(firstApproverId)
-			.orElseThrow(() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_MEMBER));
-		Member findSecondMember = memberRepository.findById(secondApproverId)
-			.orElseThrow(() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_MEMBER));
-
-		approvalStepRepository.save(ApprovalStepMapper.toEntity(findFirstMember, vacationRequest, STEP1));
-		approvalStepRepository.save(ApprovalStepMapper.toEntity(findSecondMember, vacationRequest, STEP2));
+	public void saveApprovalStep(Member firstApprover, VacationRequest vacationRequest) {
+		// todo: 2차 결재자 지정 기능 (시스템상 구현 필요)
+		Dept findDept = deptRepository.findByDeptName("인사팀")
+			.orElseThrow(() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_DEPT));
+		approvalStepRepository.save(ApprovalStepMapper.toEntity(firstApprover, vacationRequest, STEP1));
+		approvalStepRepository.save(ApprovalStepMapper.toEntity(findDept.getDeptLeader(), vacationRequest, STEP2));
 	}
 
 	// 휴가 요청 취소될 경우, 관련 결재 단계 상태 CANCELED

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
@@ -31,7 +31,6 @@ import programmers.team6.domain.vacation.enums.VacationRequestStatus;
 import programmers.team6.domain.vacation.repository.ApprovalStepRepository;
 import programmers.team6.domain.vacation.repository.VacationRepository;
 import programmers.team6.domain.vacation.repository.VacationRequestRepository;
-import programmers.team6.domain.vacation.util.mapper.ApprovalStepMapper;
 import programmers.team6.domain.vacation.util.mapper.VacationMapper;
 
 @Service
@@ -46,6 +45,8 @@ public class VacationService {
 
 	private final MemberRepository memberRepository;
 	private final CodeRepository codeRepository;
+
+	private final ApprovalStepService approvalStepService;
 
 	// 멤버 ID로 멤버를 조회, 멤버가 존재하지 않으면 예외 발생
 	private Member getMemberById(Long memberId) {
@@ -87,8 +88,7 @@ public class VacationService {
 		vacationRequestRepository.save(vacationRequest);
 
 		// 결재 단계 생성
-		ApprovalStep approvalStep = ApprovalStepMapper.toEntity(approver, vacationRequest, 1);
-		approvalStepRepository.save(approvalStep);
+		approvalStepService.saveApprovalStep(approver, vacationRequest);
 
 		// 응답 DTO 생성
 		return vacationMapper.toVacationCreateResponseDto(
@@ -206,6 +206,9 @@ public class VacationService {
 
 		// 휴가 신청 취소
 		vacationRequest.validateAndCancel(memberId);
+
+		// 1,2차 결재 취소
+		approvalStepService.cancelApprovalStep(vacationRequest.getId());
 
 		return true;
 	}

--- a/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/code/NotFoundErrorCode.java
@@ -15,7 +15,8 @@ public enum NotFoundErrorCode implements ErrorCode {
 	NOT_FOUND_CODE("존재하지 않는 코드입니다."),
 	NOT_FOUND_FIRST_APPROVAL_STEP("1차 결재 정보를 찾을 수 없습니다."),
 	NOT_FOUND_SECOND_APPROVAL_STEP("2차 결재 정보를 찾을 수 없습니다."),
-	NOT_FOUND_VACATION_INFO("휴가 정보를 찾을 수 없습니다.");
+	NOT_FOUND_VACATION_INFO("휴가 정보를 찾을 수 없습니다."),
+	NOT_FOUND_DEPT_LEADER("부서장 정보를 찾을 수 없습니다.");
 
 	private final String message;
 	private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- close #72 

## 📝작업 내용
- 2차 결재자 강재 지정
```java
	// 휴가 신청 시 호출되어, 해당 멤버의 결재 단계 생성
	public void saveApprovalStep(Member firstApprover, VacationRequest vacationRequest) {
		// todo: 2차 결재자 지정 기능 (시스템상 구현 필요)
		Dept findDept = deptRepository.findByDeptName("인사팀")
			.orElseThrow(() -> new NotFoundException(NotFoundErrorCode.NOT_FOUND_DEPT));
		approvalStepRepository.save(ApprovalStepMapper.toEntity(firstApprover, vacationRequest, STEP1));
		approvalStepRepository.save(ApprovalStepMapper.toEntity(findDept.getDeptLeader(), vacationRequest, STEP2));
	}
```
- 휴가 신청, 취소 부분에 메서드 연결
```java
// 휴가 신청 메서드
                 // 결재 단계 생성
		approvalStepService.saveApprovalStep(approver, vacationRequest);

// 휴가 취소 메서드
                 // 1,2차 결재 취소
		approvalStepService.cancelApprovalStep(vacationRequest.getId());
```

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
