### PR TITLE
feat(87) : 회원가입 화면 구현

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/auth/dto/request/MemberSignUpRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/auth/dto/request/MemberSignUpRequest.java
@@ -5,11 +5,13 @@ import java.time.LocalDateTime;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Pattern;
 
 public record MemberSignUpRequest(
 
 	@NotBlank(message = "이름은 필수입니다.")
+	@Pattern(regexp = "^[가-힣]{2,10}$", message = "공백을 제거하거나 한글 이름만 입력해주세요.")
 	String name,
 
 	@Email(message = "이메일 형식이 아닙니다.")
@@ -23,6 +25,7 @@ public record MemberSignUpRequest(
 	String position,
 
 	@NotNull(message = "입사 날짜는 필수입니다.")
+	@PastOrPresent(message = "미래 날짜는 허용되지 않습니다.")
 	LocalDateTime joinDate,
 
 	@NotBlank(message = "생년월일 선택은 필수입니다.")
@@ -30,7 +33,7 @@ public record MemberSignUpRequest(
 
 	@NotBlank(message = "비밀번호 입력은 필수입니다.")
 	@Pattern(
-		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,}$",
+		regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*~])[A-Za-z\\d!@#$%^&*]{8,}$",
 		message = "비밀번호는 영문자, 숫자, 특수문자를 포함해 8자 이상이어야 합니다."
 	)
 	String password

--- a/backend/team6/src/main/java/programmers/team6/global/exception/customException/CustomException.java
+++ b/backend/team6/src/main/java/programmers/team6/global/exception/customException/CustomException.java
@@ -8,7 +8,7 @@ public abstract class CustomException extends RuntimeException {
 
 	private final ErrorCode errorCode;
 
-	public CustomException(ErrorCode errorCode) {
+	protected CustomException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 	}

--- a/front/team06/package-lock.json
+++ b/front/team06/package-lock.json
@@ -12,11 +12,13 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.9.0",
         "lucide-react": "^0.510.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0",
         "react-scripts": "5.0.1",
+        "styled-components": "^6.1.18",
         "web-vitals": "^2.1.4"
       }
     },
@@ -2352,6 +2354,27 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "license": "MIT"
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
@@ -3897,6 +3920,12 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -4895,6 +4924,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -5463,6 +5518,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -6006,6 +6070,15 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
@@ -6154,6 +6227,17 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "license": "MIT"
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
@@ -6361,6 +6445,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -13635,6 +13725,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -14933,6 +15029,12 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15602,6 +15704,68 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.18.tgz",
+      "integrity": "sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -15617,6 +15781,12 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/front/team06/package.json
+++ b/front/team06/package.json
@@ -1,5 +1,6 @@
 {
   "name": "team06",
+  "proxy": "http://localhost:8080",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -7,11 +8,13 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.9.0",
     "lucide-react": "^0.510.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
     "react-scripts": "5.0.1",
+    "styled-components": "^6.1.18",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/front/team06/src/App.js
+++ b/front/team06/src/App.js
@@ -5,14 +5,20 @@ import {
   Route,
 } from 'react-router-dom';
 import DefaultLayout from './pages/component/default-layout';
-import Vacations from "./pages/component/vacations/vacations";
+import Login from'./pages/component/auth/login';
+import SignUp from'./pages/component/auth/signUp';
+import {Navigate} from "react-router-dom";
+
 
 function App() {
   return (
       <Router>
         <DefaultLayout>
           <Routes>
-              <Route path="/vacations" element={<Vacations />} />
+              <Route path="/" element={<Navigate to="/auth/login" />} />
+
+              <Route path="/auth/login" element={<Login />} />
+              <Route path="/auth/signup" element={<SignUp />} />
           </Routes>
         </DefaultLayout>
       </Router>

--- a/front/team06/src/pages/component/auth/login.jsx
+++ b/front/team06/src/pages/component/auth/login.jsx
@@ -1,0 +1,173 @@
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { colors, spacing, typography } from '../styles/design-tokens';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const Login = () => {
+
+    const navigate = useNavigate();
+
+    const goToSignUp = () => {
+        navigate("/auth/signup");
+    }
+
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+
+    const handleLogin = async (e) => {
+        e.preventDefault();
+
+        try{
+            const response = await axios.post("/auth/login",
+                {email,password},
+                {withCredentials: true});
+
+            const {token} = response.data;
+
+            localStorage.setItem("accessToken",token.accessToken);
+            localStorage.setItem("userId",token.id);
+            localStorage.setItem("userName",token.name);
+            localStorage.setItem("userRole",token.role);
+
+            //todo 로그인 성공 처리
+            alert(`${token.name}님 환영합니다.`);
+
+        }catch(error){
+            if(error.response){
+                const {message,Codename,status} = error.response.data;
+
+                alert(message);
+
+
+            }
+        }
+
+    };
+
+    return (
+        <FormContainer onSubmit={handleLogin}>
+            <Header>로그인</Header>
+            <InputGroup>
+                <InputWrapper>
+                    <Label htmlFor="email">이메일</Label>
+                    <Input
+                        type="email"
+                        id="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                    />
+                </InputWrapper>
+                <InputWrapper>
+                    <Label htmlFor="password">비밀번호</Label>
+                    <Input
+                        type="password"
+                        id="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                    />
+                </InputWrapper>
+            </InputGroup>
+            <PrimaryButton type="submit">로그인</PrimaryButton>
+            <SignupText>
+                계정이 없으신가요? <SignupLink onClick={goToSignUp}>회원가입</SignupLink>
+            </SignupText>
+        </FormContainer>
+    );
+};
+
+export default Login;
+
+// styled-components
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+  margin: 0 auto;
+  margin-top: 100px;
+  background-color: ${colors.primaryBackground};
+  padding: ${spacing.lg};
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+`;
+
+const Header = styled.h2`
+  font-size: ${typography.fontSizes.xxl};
+  font-weight: 700;
+  margin-bottom: ${spacing.lg};
+  color: ${colors.primaryText};
+  text-align: center;
+`;
+
+const InputGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.md};
+  margin-bottom: ${spacing.md};
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Label = styled.label`
+  margin-bottom: ${spacing.xs};
+  color: ${colors.primaryText};
+  font-size: ${typography.fontSizes.sm};
+`;
+
+const Input = styled.input`
+  width: 100%;
+  height: 40px;
+  font-size: ${typography.fontSizes.md};
+  font-family: ${typography.fontFamily};
+  color: ${colors.primaryText};
+  border: 1px solid ${colors.borderColor};
+  border-radius: 4px;
+  background-color: #fff;
+
+  &:focus {
+    outline: none;
+    border-color: ${colors.primary};
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.2);
+  }
+`;
+
+const PrimaryButton = styled.button`
+  background-color: ${colors.primary};
+  color: white;
+  font-size: ${typography.fontSizes.md};
+  padding: ${spacing.sm} ${spacing.lg};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  margin-top: ${spacing.md};
+
+  &:hover {
+    background-color: #1565c0;
+  }
+`;
+
+const SignupText = styled.p`
+  margin-top: ${spacing.md};
+  font-size: ${typography.fontSizes.sm};
+  color: ${colors.secondaryText};
+  text-align: center;
+`;
+
+const SignupLink = styled.a`
+  color: ${colors.primary};
+  text-decoration: none;
+  font-weight: 500;
+  margin-left: 4px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/front/team06/src/pages/component/auth/signUp.jsx
+++ b/front/team06/src/pages/component/auth/signUp.jsx
@@ -1,0 +1,373 @@
+
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { colors, spacing, typography } from '../styles/design-tokens';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const SignUp = () => {
+
+    const [positions, setPositions] = useState([]);
+    const [depts, setDepts] = useState([]);
+
+    useEffect(() => {
+        // 직위 코드 가져오기
+        axios.get('/codes/group/POSITION')
+            .then(res => {
+                setPositions(res.data);
+            })
+            .catch(err => {
+                console.error("직위 조회 실패", err);
+            });
+
+        // 부서 목록 가져오기
+        axios.get('/depts')
+            .then(res => {
+                setDepts(res.data);
+            })
+            .catch(err => {
+                console.error("부서 조회 실패", err);
+            });
+    }, []);
+
+
+    const [emailCheckMessage, setEmailCheckMessage] = useState('');
+    const [isEmailAvailable, setIsEmailAvailable] = useState(null);
+
+
+    const handleEmailCheck = async () => {
+        if (!form.email) {
+            setEmailCheckMessage('이메일을 입력해주세요.');
+            setIsEmailAvailable(false);
+            return;
+        }
+
+
+        const res = await axios.get(`/auth/email-duplicate-check?email=${form.email}`);
+        const isDuplicated = res.data.isEmailDuplicated;
+        if(!isDuplicated){
+            setEmailCheckMessage('✅ 사용 가능한 이메일입니다.');
+            setIsEmailAvailable(true);
+        }else{
+            setEmailCheckMessage('❌ 이미 존재하는 이메일입니다.');
+            setIsEmailAvailable(false);
+        }
+    };
+
+
+
+    const navigate = useNavigate();
+
+    const [form, setForm] = useState({
+        name: '',
+        email: '',
+        dept: '',
+        position: '',
+        joinDate: '',
+        birth: '',
+        password: '',
+    });
+
+
+    useEffect(() => {
+        setIsEmailAvailable(false);
+        setEmailCheckMessage('');
+    }, [form.email]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setForm((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
+
+
+    const [passwordMessage, setPasswordMessage] = useState('');
+
+    useEffect(() => {
+        if (!form.password) {
+            setPasswordMessage('');
+        } else if (!passwordRegex.test(form.password)) {
+            setPasswordMessage('영문자, 숫자, 특수문자를 포함해 8자 이상으로 입력해주세요.');
+        } else {
+            setPasswordMessage('');
+        }
+    }, [form.password]);
+
+
+    const [errorMessages , setErrorMessages] = useState({});
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (!passwordRegex.test(form.password)) {
+            setPasswordMessage('비밀번호 조건을 다시 확인해주세요.');
+            return;
+        }
+
+        try {
+            await axios.post('/auth/signup', {
+                ...form,
+                joinDate: new Date(form.joinDate),
+            });
+            alert('회원가입 성공!');
+            window.location.href = '/auth/login';
+        } catch (err) {
+            const httpsStatus = err.response?.status;
+            const customStatus = err.response?.data?.status;
+            const codeName = err.response?.data?.codeName;
+
+            if(customStatus === 400 && codeName === 'BAD_REQUEST_VALIDATION'){
+                setErrorMessages(err.response.data.errors);
+            }
+        }
+    };
+
+
+    const handleCancel = () => {
+        navigate('/auth/login');
+    };
+
+    return (
+        <FormContainer onSubmit={handleSubmit}>
+            <Header>회원가입</Header>
+
+            <InputGroup>
+                <Label htmlFor="email">이메일</Label>
+                <EmailCheckWrapper>
+                    <EmailInput
+                        name="email"
+                        value={form.email}
+                        onChange={handleChange}
+                        required
+                    />
+                    <EmailCheckButton type="button" onClick={handleEmailCheck}>
+                        중복 확인
+                    </EmailCheckButton>
+                </EmailCheckWrapper>
+                {emailCheckMessage && (
+                    <p style={{ color: isEmailAvailable ? 'green' : 'red' }}>
+                        {emailCheckMessage}
+                    </p>
+                )}
+                {errorMessages.email && (
+                    <ErrorText>{errorMessages.email}</ErrorText>
+                )}
+                <Label htmlFor="name">이름</Label>
+                <Input
+                    name="name"
+                    type="text"
+                    value={form.name}
+                    onChange={handleChange}
+                    required
+                />
+                {errorMessages.name && (
+                    <ErrorText>{errorMessages.name}</ErrorText>
+                )}
+                <label htmlFor="dept">부서</label>
+                <StyledSelect
+                    id="dept"
+                    name="dept"
+                    value={form.dept}
+                    onChange={handleChange}
+                    required
+                >
+                    <option value="">선택</option>
+                    {depts.map(dept => (
+                        <option key={dept.id} value={dept.id}>{dept.name}</option>
+                    ))}
+                </StyledSelect>
+                {errorMessages.dept && (
+                    <ErrorText>{errorMessages.dept}</ErrorText>
+                )}
+
+                <label htmlFor="position">직위</label>
+                <StyledSelect
+                    id="position"
+                    name="position"
+                    value={form.position}
+                    onChange={handleChange}
+                    required
+                >
+                    <option value="">선택</option>
+                    {positions.map(pos => (
+                        <option key={pos.code} value={pos.code}>{pos.name}</option>
+                    ))}
+                </StyledSelect>
+                {errorMessages.position && (
+                    <ErrorText>{errorMessages.position}</ErrorText>
+                )}
+                <Label htmlFor="joinDate">입사 날짜</Label>
+                <Input name="joinDate" type="date" value={form.joinDate} onChange={handleChange} required  />
+                {errorMessages.joinDate && (
+                    <ErrorText>{errorMessages.joinDate}</ErrorText>
+                )}
+
+                <Label htmlFor="birth">생년월일</Label>
+                <Input name="birth" type="date" value={form.birth} onChange={handleChange} required  />
+                {errorMessages.birth && (
+                    <ErrorText>{errorMessages.birth}</ErrorText>
+                )}
+
+                <Label htmlFor="password">비밀번호</Label>
+                <Input name="password" type="password" value={form.password} onChange={handleChange} required  />
+                {errorMessages.password && (
+                    <ErrorText>{errorMessages.password}</ErrorText>
+                )}
+                {passwordMessage && (
+                    <ErrorText>{passwordMessage}</ErrorText>
+                )}
+            </InputGroup>
+
+            <ButtonGroup>
+                <PrimaryButton disabled={!isEmailAvailable} type="submit">회원가입</PrimaryButton>
+                <SecondaryButton type="button" onClick={handleCancel}>취소</SecondaryButton>
+            </ButtonGroup>
+        </FormContainer>
+    );
+};
+
+export default SignUp;
+
+// styled-components
+const FormContainer = styled.form`
+  max-width: 480px;
+  margin: 0 auto;
+  margin-top: 100px;
+  padding: ${spacing.lg};
+  background: ${colors.primaryBackground};
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+`;
+
+const Header = styled.h2`
+  font-size: ${typography.fontSizes.xxl};
+  font-weight: 700;
+  margin-bottom: ${spacing.lg};
+  color: ${colors.primaryText};
+  text-align: center;
+`;
+
+const InputGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.md};
+`;
+
+const Label = styled.label`
+  font-size: ${typography.fontSizes.sm};
+  color: ${colors.primaryText};
+  margin-bottom: ${spacing.xs};
+`;
+
+const Input = styled.input`
+  height: 40px;
+  padding: 0 ${spacing.md};
+  font-size: ${typography.fontSizes.md};
+  font-family: ${typography.fontFamily};
+  color: ${colors.primaryText};
+  border: 1px solid ${colors.borderColor};
+  border-radius: 4px;
+  background-color: #fff;
+
+  &:focus {
+    outline: none;
+    border-color: ${colors.primary};
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.2);
+  }
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: ${spacing.sm};
+  margin-top: ${spacing.lg};
+`;
+
+const PrimaryButton = styled.button`
+  flex: 1;
+  background-color: ${colors.primary};
+  color: white;
+  font-size: ${typography.fontSizes.md};
+  padding: ${spacing.sm} ${spacing.lg};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover {
+    background-color: #1565c0;
+  }
+&:disabled {
+background-color: ${colors.borderColor}; // 흐리게
+color: #ccc;
+cursor: not-allowed;
+opacity: 0.6;
+  }
+`;
+const SecondaryButton = styled.button`
+  flex: 1;
+  background-color: transparent;
+  color: ${colors.primary};
+  font-size: ${typography.fontSizes.md};
+  padding: ${spacing.sm} ${spacing.lg};
+  border: 1px solid ${colors.primary};
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover {
+    background-color: rgba(25, 118, 210, 0.05);
+  }
+`;
+const EmailCheckWrapper = styled.div`
+  display: flex;
+  gap: ${spacing.sm};
+  align-items: center;
+`;
+
+const EmailCheckButton = styled.button`
+  white-space: nowrap;
+  padding: 0 ${spacing.md};
+  height: 40px;
+  font-size: ${typography.fontSizes.sm};
+  border: 1px solid ${colors.primary};
+  border-radius: 4px;
+  background-color: transparent;
+  color: ${colors.primary};
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover {
+    background-color: rgba(25, 118, 210, 0.05);
+  }
+`;
+
+const StyledSelect = styled.select`
+  height: 40px;
+  padding: 0 ${spacing.md};
+  font-size: ${typography.fontSizes.md};
+  font-family: ${typography.fontFamily};
+  color: ${colors.primaryText};
+  border: 1px solid ${colors.borderColor};
+  border-radius: 4px;
+  background-color: #fff;
+
+  &:focus {
+    outline: none;
+    border-color: ${colors.primary};
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.2);
+  }
+`;
+const EmailInput = styled(Input)`
+  width: 100%;
+  min-width: 280px;
+  flex: 1;
+`;
+const ErrorText = styled.p`
+  color: red;
+  font-size: 12px;
+  margin-top: 4px;
+  margin-left: 2px;
+`;
+

--- a/front/team06/src/pages/component/default-layout.jsx
+++ b/front/team06/src/pages/component/default-layout.jsx
@@ -178,7 +178,7 @@ const DefaultLayout = ({ children }) => {
             </footer>
 
             {/* Mobile sidebar overlay */}
-            {!isAuthPage && !!sidebarCollapsed && (
+            {!isAuthPage && !sidebarCollapsed && (
                 <div
                     className="lg:hidden fixed inset-0 bg-black bg-opacity-50 z-10"
                     onClick={() => setSidebarCollapsed(true)}

--- a/front/team06/src/pages/component/default-layout.jsx
+++ b/front/team06/src/pages/component/default-layout.jsx
@@ -5,6 +5,10 @@ const DefaultLayout = ({ children }) => {
     const navigate = useNavigate();
     const location = useLocation();
 
+    const isAuthPage = location.pathname === '/auth/login' || location.pathname === '/auth/signup';
+    //로그인, 회원가입에서는 sidebar,이름 정보 삭제  삭제
+
+
     const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
     // setActiveMenu 삭제하고 이걸로 교체
     const activeMenu = location.pathname.includes('/admin/vacation-request') ? 'vacation-list'
@@ -66,7 +70,9 @@ const DefaultLayout = ({ children }) => {
                             onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
                             className="p-2 rounded-md hover:bg-gray-100 lg:hidden"
                         >
-                            <span className="text-gray-600">☰</span>
+                            {!isAuthPage && (
+                                <span className="text-gray-600">☰</span>
+                            )}
                         </button>
                         <div className="ml-4 flex items-center">
                             <h1 className="text-xl font-bold text-gray-900">휴가 관리 시스템</h1>
@@ -74,10 +80,8 @@ const DefaultLayout = ({ children }) => {
                     </div>
 
                     {/* Right side - User menu */}
+                    {!isAuthPage && (
                     <div className="flex items-center space-x-4">
-                        <button className="p-2 rounded-md hover:bg-gray-100">
-                            <span className="text-gray-600">🔔</span>
-                        </button>
                         <div className="flex items-center space-x-3">
                             <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
                                 <span className="text-white text-sm font-medium">김</span>
@@ -91,10 +95,12 @@ const DefaultLayout = ({ children }) => {
                             </button>
                         </div>
                     </div>
+                    )}
                 </div>
             </header>
 
             {/* Sidebar */}
+            {!isAuthPage && (
             <aside className={`fixed top-16 left-0 h-full bg-white shadow-lg border-r border-gray-200 transition-width duration-300 z-20 ${
                 sidebarCollapsed ? 'w-16' : 'w-60'
             }`}>
@@ -142,10 +148,11 @@ const DefaultLayout = ({ children }) => {
                     </div>
                 </div>
             </aside>
+            )}
 
             {/* Main content */}
             <main className={`pt-16 transition-all duration-300 ${
-                sidebarCollapsed ? 'ml-16' : 'ml-60'
+                isAuthPage ? '' :sidebarCollapsed ? 'ml-16' : 'ml-60'
             }`}>
                 <div className="min-h-screen">
                     {children}
@@ -154,7 +161,7 @@ const DefaultLayout = ({ children }) => {
 
             {/* Footer */}
             <footer className={`bg-white border-t border-gray-200 transition-all duration-300 ${
-                sidebarCollapsed ? 'ml-16' : 'ml-60'
+                isAuthPage ? '':sidebarCollapsed ? 'ml-16' : 'ml-60'
             }`}>
                 <div className="px-6 py-4">
                     <div className="flex flex-col md:flex-row md:items-center md:justify-between">
@@ -171,7 +178,7 @@ const DefaultLayout = ({ children }) => {
             </footer>
 
             {/* Mobile sidebar overlay */}
-            {!sidebarCollapsed && (
+            {!isAuthPage && !!sidebarCollapsed && (
                 <div
                     className="lg:hidden fixed inset-0 bg-black bg-opacity-50 z-10"
                     onClick={() => setSidebarCollapsed(true)}

--- a/front/team06/src/pages/component/styles/design-tokens.js
+++ b/front/team06/src/pages/component/styles/design-tokens.js
@@ -1,0 +1,27 @@
+export const colors = {
+    primary: '#1976D2',
+    secondary: '#FF9800',
+    success: '#4CAF50',
+    // ... 기타 색상
+};
+
+export const spacing = {
+    xs: '4px',
+    sm: '8px',
+    md: '16px',
+    lg: '24px',
+    xl: '32px',
+};
+
+export const typography = {
+    fontFamily: "'Noto Sans KR', 'Roboto', sans-serif",
+    fontSizes: {
+        xs: '12px',
+        sm: '14px',
+        md: '16px',
+        lg: '18px',
+        xl: '20px',
+        xxl: '24px',
+    },
+    // ... 기타 타이포그래피 속성
+};


### PR DESCRIPTION
close #87 #91 

## #️⃣연관된 이슈 번호
- #87 #91 

## 📝작업 내용

## front
- 로그인, 회원가입 화면에서 layout 분기처리 (사이드바, user 정보 안보이게 처리) 

```javascript
 const isAuthPage = location.pathname === '/auth/login' || location.pathname === '/auth/signup';
    //로그인, 회원가입에서는 sidebar,이름 정보 삭제  삭제
``` 

- 로그인, 회원가입 화면 추가 

<img width="1486" alt="스크린샷 2025-05-17 오후 6 00 16" src="https://github.com/user-attachments/assets/8edeea31-5f7e-4022-b888-14ffa3db1f01" />
<img width="1490" alt="스크린샷 2025-05-17 오후 6 00 37" src="https://github.com/user-attachments/assets/d8d0ef1f-4247-4500-b2c3-10b736263ccd" />


![스크린샷 2025-05-15 오후 10 16 27](https://github.com/user-attachments/assets/67024722-0a66-4653-a09e-5bf96f4f3c50)



## back
- 회원가입 유효성 체크 추가 
- 이름 공백 유효성, 입사날짜 유효성, 비밀번호 입력 시 특수문자 ~ 물결 추가 

- customException 생성자 public -> protected 변경 


## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
