### PR TITLE
refactor(90): JWT 기반으로 휴가 CRUD memberId 처리하도록 수정

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
@@ -1,6 +1,7 @@
 package programmers.team6.domain.vacation.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import programmers.team6.domain.auth.dto.TokenBody;
 import programmers.team6.domain.vacation.dto.VacationCancelResponseDto;
 import programmers.team6.domain.vacation.dto.VacationCreateRequestDto;
 import programmers.team6.domain.vacation.dto.VacationCreateResponseDto;
@@ -29,9 +31,11 @@ public class VacationController {
 
 	private final VacationService vacationService;
 
-	@GetMapping("/my/{memberId}")
+	@GetMapping("/my")
 	public ResponseEntity<VacationInfoSelectResponseDto> getMyVacationInfo(
-		@PathVariable Long memberId) {
+		@AuthenticationPrincipal TokenBody tokenBody) {
+
+		Long memberId = tokenBody.id();
 
 		// 휴가 정보 조회
 		VacationInfoSelectResponseDto vacationInfo = vacationService.getMyVacationInfo(memberId);
@@ -40,40 +44,47 @@ public class VacationController {
 	}
 
 	// 휴가 신청
-	@PostMapping("/{memberId}")
+	@PostMapping
 	public ResponseEntity<VacationCreateResponseDto> requestVacation(
 		@Validated @RequestBody VacationCreateRequestDto requestDto,
-		@PathVariable Long memberId) {
+		@AuthenticationPrincipal TokenBody tokenBody) {
+
+		Long memberId = tokenBody.id();
 		VacationCreateResponseDto response = vacationService.requestVacation(memberId, requestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	// 휴가 신청 리스트 (페이징 조회)
-	@GetMapping("/{memberId}")
+	@GetMapping
 	public ResponseEntity<VacationListResponseDto> getVacationRequestList(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@RequestParam(defaultValue = "0") int page) {
 
+		Long memberId = tokenBody.id();
 		VacationListResponseDto response = vacationService.getVacationRequestList(memberId, page);
 		return ResponseEntity.ok(response);
 	}
 
 	// 휴가 신청 수정
-	@PutMapping("/{memberId}/{requestId}")
+	@PutMapping("/{requestId}")
 	public ResponseEntity<VacationUpdateResponseDto> updateVacationRequest(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@PathVariable Long requestId,
 		@Validated @RequestBody VacationUpdateRequestDto requestDto) {
+
+		Long memberId = tokenBody.id();
 		VacationUpdateResponseDto response = vacationService.updateVacationRequest(memberId, requestId, requestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	// 대기중인 휴가 신청 취소
-	@DeleteMapping("/{memberId}/{requestId}")
+	@DeleteMapping("/{requestId}")
 	public ResponseEntity<?> cancelVacationRequest(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@PathVariable Long requestId) {
 
+		Long memberId = tokenBody.id();
+		
 		boolean success = vacationService.cancelVacationRequest(memberId, requestId);
 
 		VacationCancelResponseDto response = VacationCancelResponseDto.builder()

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
@@ -69,11 +69,11 @@ public class VacationService {
 	@Transactional
 	public VacationCreateResponseDto requestVacation(Long memberId, VacationCreateRequestDto requestDto) {
 		// 신청자 정보 조회
-		Member requester = memberRepository.findByIdWithDeptAndLeader(memberId)
+		Member member = memberRepository.findByIdWithDeptAndLeader(memberId)
 			.orElseThrow(() -> new RuntimeException("멤버 정보를 찾을 수 없습니다."));
 
 		// 부서장 조회 (결재자)
-		Dept dept = requester.getDept();
+		Dept dept = member.getDept();
 		Member approver = dept.getDeptLeader();
 
 		// 휴가 유형 코드 조회
@@ -84,7 +84,7 @@ public class VacationService {
 		VacationRequestStatus status = VacationRequestStatus.IN_PROGRESS;
 
 		// 휴가 요청 생성
-		VacationRequest vacationRequest = vacationMapper.toVacationRequest(requestDto, vacationType, status, requester);
+		VacationRequest vacationRequest = vacationMapper.toVacationRequest(requestDto, vacationType, status, member);
 		vacationRequestRepository.save(vacationRequest);
 
 		// 결재 단계 생성

--- a/front/team06/package-lock.json
+++ b/front/team06/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.9.0",
         "lucide-react": "^0.510.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -4893,6 +4894,32 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13634,6 +13661,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/front/team06/package.json
+++ b/front/team06/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.9.0",
     "lucide-react": "^0.510.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/front/team06/src/pages/component/vacations/vacation-request-modal.jsx
+++ b/front/team06/src/pages/component/vacations/vacation-request-modal.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+
+const VacationRequestModal = ({ isOpen, onClose, onSubmit }) => {
+    const [formData, setFormData] = useState({
+        type: '연차',
+        from: '',
+        to: '',
+        reason: ''
+    });
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        onSubmit(formData);
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+                <h3 className="text-lg font-semibold mb-4">휴가 신청</h3>
+                <form onSubmit={handleSubmit}>
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">휴가 유형</label>
+                        <select
+                            name="type"
+                            value={formData.type}
+                            onChange={handleChange}
+                            className="w-full border border-gray-300 rounded-md px-3 py-2"
+                        >
+                            <option value="연차">연차</option>
+                            <option value="반차">반차</option>
+                            <option value="병가">병가</option>
+                            <option value="경조사">경조사</option>
+                        </select>
+                    </div>
+
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">시작일</label>
+                        <input
+                            type="date"
+                            name="from"
+                            value={formData.from}
+                            onChange={handleChange}
+                            className="w-full border border-gray-300 rounded-md px-3 py-2"
+                        />
+                    </div>
+
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">종료일</label>
+                        <input
+                            type="date"
+                            name="to"
+                            value={formData.to}
+                            onChange={handleChange}
+                            className="w-full border border-gray-300 rounded-md px-3 py-2"
+                        />
+                    </div>
+
+                    <div className="mb-4">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">사유</label>
+                        <textarea
+                            name="reason"
+                            value={formData.reason}
+                            onChange={handleChange}
+                            className="w-full border border-gray-300 rounded-md px-3 py-2"
+                            rows="3"
+                        ></textarea>
+                    </div>
+
+                    <div className="flex justify-end mt-4">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="mr-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300"
+                        >
+                            취소
+                        </button>
+                        <button
+                            type="submit"
+                            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                        >
+                            신청
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default VacationRequestModal;

--- a/front/team06/src/pages/component/vacations/vacations.jsx
+++ b/front/team06/src/pages/component/vacations/vacations.jsx
@@ -1,0 +1,228 @@
+import React, { useState, useEffect } from 'react';
+import VacationRequestModal from './vacation-request-modal';
+
+const Vacations = () => {
+    // 휴가 데이터 상태 관리
+    const [vacationData, setVacationData] = useState({
+        totalCount: 15,
+        useCount: 2,
+        remainCount: 13
+    });
+
+    // 휴가 신청 목록 데이터 상태 관리
+    const [vacationList, setVacationList] = useState([
+        {
+            id: 1,
+            type: '연차',
+            from: '2025-05-15',
+            to: '2025-05-15',
+            days: 1,
+            reason: '개인 사유',
+            status: '승인',
+            approver: '김부장'
+        },
+        {
+            id: 2,
+            type: '반차',
+            from: '2025-04-22',
+            to: '2025-04-22',
+            days: 0.5,
+            reason: '병원 진료',
+            status: '승인',
+            approver: '김부장'
+        },
+        {
+            id: 3,
+            type: '연차',
+            from: '2025-03-10',
+            to: '2025-03-11',
+            days: 2,
+            reason: '개인 사유',
+            status: '취소',
+            approver: '-'
+        }
+    ]);
+
+    // 휴가 신청 모달 상태
+    const [showModal, setShowModal] = useState(false);
+
+    // 실제 구현 시에는 API 호출로 데이터를 가져옴
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                // 사용자 ID는 실제 로그인 정보에서 가져와야 함
+                const memberId = 1; // 임시로 1로 설정
+
+                const infoResponse = await fetch(`/vacations/my/${memberId}`);
+                if (infoResponse.ok) {
+                    const vacationInfo = await infoResponse.json();
+                    setVacationData(vacationInfo);
+                }
+
+                const listResponse = await fetch(`/vacations/${memberId}?page=0`);
+                if (listResponse.ok) {
+                    const vacationListData = await listResponse.json();
+                    setVacationList(vacationListData.content || []);
+                }
+            } catch (error) {
+                console.error('데이터 로딩 오류:', error);
+                // 에러 처리는 실제 구현 시 추가
+            }
+        };
+
+        // 주석 처리: 실제 API 연동 시 주석 해제
+        // fetchData();
+    }, []);
+
+    // 휴가 신청 처리 함수
+    const handleVacationRequest = async (formData) => {
+        try {
+            // 사용자 ID는 실제 로그인 정보에서 가져와야 함
+            const memberId = 1; // 임시로 1로 설정
+
+            const response = await fetch(`/vacations/${memberId}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    from: new Date(formData.from).toISOString(),
+                    to: new Date(formData.to).toISOString(),
+                    reason: formData.reason,
+                    vacationType: formData.type === '연차' ? '01' :
+                        formData.type === '반차' ? '05' :
+                            formData.type === '병가' ? '02' : '03'
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error('휴가 신청에 실패했습니다.');
+            }
+
+            // 성공 후 데이터 새로고침
+            // 휴가 정보 다시 불러오기
+            const infoResponse = await fetch(`/vacations/my/${memberId}`);
+            if (infoResponse.ok) {
+                const vacationInfo = await infoResponse.json();
+                setVacationData(vacationInfo);
+            }
+
+            // 휴가 목록 다시 불러오기
+            const listResponse = await fetch(`/vacations/${memberId}?page=0`);
+            if (listResponse.ok) {
+                const vacationListData = await listResponse.json();
+                setVacationList(vacationListData.content || []);
+            }
+
+            setShowModal(false);
+            alert('휴가 신청이 완료되었습니다.');
+        } catch (error) {
+            console.error('휴가 신청 오류:', error);
+            alert('휴가 신청에 실패했습니다. 다시 시도해주세요.');
+        }
+    };
+
+    return (
+        <div className="p-6">
+            {/* 휴가 현황 카드 섹션 */}
+            <div className="mb-6">
+                <h2 className="text-xl font-semibold text-gray-800 mb-4">휴가 현황</h2>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div className="bg-white rounded-lg shadow p-6">
+                        <div className="flex flex-col items-center">
+                            <div className="text-sm text-gray-600">부여휴가</div>
+                            <div className="text-3xl font-bold text-blue-600 mt-2">{vacationData.totalCount}일</div>
+                        </div>
+                    </div>
+
+                    <div className="bg-white rounded-lg shadow p-6">
+                        <div className="flex flex-col items-center">
+                            <div className="text-sm text-gray-600">사용휴가</div>
+                            <div className="text-3xl font-bold text-red-600 mt-2">{vacationData.useCount}일</div>
+                        </div>
+                    </div>
+
+                    <div className="bg-white rounded-lg shadow p-6">
+                        <div className="flex flex-col items-center">
+                            <div className="text-sm text-gray-600">잔여휴가</div>
+                            <div className="text-3xl font-bold text-green-600 mt-2">{vacationData.remainCount}일</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* 휴가 신청 목록 섹션 */}
+            <div className="bg-white rounded-lg shadow">
+                <div className="p-6 border-b border-gray-200 flex justify-between items-center">
+                    <h2 className="text-xl font-semibold text-gray-800">휴가 신청 목록</h2>
+                    <button
+                        onClick={() => setShowModal(true)}
+                        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+                    >
+                        휴가 신청
+                    </button>
+                </div>
+
+                {/* 테이블 */}
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                        <tr>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">번호</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">휴가 유형</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">시작일</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">종료일</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">일수</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">사유</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">상태</th>
+                            <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">결재자</th>
+                        </tr>
+                        </thead>
+                        <tbody className="bg-white divide-y divide-gray-200">
+                        {vacationList.map((vacation) => (
+                            <tr key={vacation.id}>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.id}</td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.type}</td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.from}</td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.to}</td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.days}</td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.reason}</td>
+                                <td className="py-4 px-6 text-sm">
+                    <span
+                        className={`px-2 py-1 text-xs rounded-full ${
+                            vacation.status === '승인'
+                                ? 'bg-green-100 text-green-800'
+                                : vacation.status === '대기'
+                                    ? 'bg-yellow-100 text-yellow-800'
+                                    : 'bg-gray-100 text-gray-800'
+                        }`}
+                    >
+                      {vacation.status}
+                    </span>
+                                </td>
+                                <td className="py-4 px-6 text-sm text-gray-900">{vacation.approver}</td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                {/* 데이터가 없을 경우 표시 */}
+                {vacationList.length === 0 && (
+                    <div className="py-10 text-center text-gray-500">
+                        휴가 신청 내역이 없습니다.
+                    </div>
+                )}
+            </div>
+
+            {/* 휴가 신청 모달 */}
+            <VacationRequestModal
+                isOpen={showModal}
+                onClose={() => setShowModal(false)}
+                onSubmit={handleVacationRequest}
+            />
+        </div>
+    );
+};
+
+export default Vacations;

--- a/front/team06/src/services/vacation-service.js
+++ b/front/team06/src/services/vacation-service.js
@@ -1,0 +1,30 @@
+export const getVacationInfo = async (memberId) => {
+    const response = await fetch(`/vacations/my/${memberId}`);
+    if (!response.ok) {
+        throw new Error('휴가 정보를 불러오는데 실패했습니다.');
+    }
+    return await response.json();
+};
+
+export const getVacationList = async (memberId, page = 0) => {
+    const response = await fetch(`/vacations/${memberId}?page=${page}`);
+    if (!response.ok) {
+        throw new Error('휴가 목록을 불러오는데 실패했습니다.');
+    }
+    return await response.json();
+};
+
+export const requestVacation = async (memberId, vacationData) => {
+    const response = await fetch(`/vacations/${memberId}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(vacationData),
+    });
+
+    if (!response.ok) {
+        throw new Error('휴가 신청에 실패했습니다.');
+    }
+    return await response.json();
+};


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #90 

## 📝작업 내용
- JWT 토큰을 통해 로그인한 사용자 정보에서 memberId 조회
```
// 휴가 신청
	@PostMapping
	public ResponseEntity<VacationCreateResponseDto> requestVacation(
		@Validated @RequestBody VacationCreateRequestDto requestDto,
		@AuthenticationPrincipal TokenBody tokenBody) {

		Long memberId = tokenBody.id();
		VacationCreateResponseDto response = vacationService.requestVacation(memberId, requestDto);
		return ResponseEntity.ok(response);
	}
```

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
memberId를 매개변수로 받고 있어서, JWT 토큰으로 받게 수정했습니다 !
