### PR TITLE
refactor(102): JWT 기반으로 휴가 CRUD memberId 처리하도록 수정

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
@@ -1,5 +1,7 @@
 package programmers.team6.domain.vacation.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -21,6 +23,7 @@ import programmers.team6.domain.vacation.dto.VacationCreateRequestDto;
 import programmers.team6.domain.vacation.dto.VacationCreateResponseDto;
 import programmers.team6.domain.vacation.dto.VacationInfoSelectResponseDto;
 import programmers.team6.domain.vacation.dto.VacationListResponseDto;
+import programmers.team6.domain.vacation.dto.VacationRequestCalendarResponse;
 import programmers.team6.domain.vacation.dto.VacationUpdateRequestDto;
 import programmers.team6.domain.vacation.dto.VacationUpdateResponseDto;
 import programmers.team6.domain.vacation.service.VacationService;
@@ -97,4 +100,13 @@ public class VacationController {
 		return ResponseEntity.ok(response);
 	}
 
+	@GetMapping("/calendar")
+	public ResponseEntity<?> selectVacationCalendar(@RequestParam String yearMonth, @RequestParam Long deptId) {
+		log.info("yearMonth = {}", yearMonth);
+		log.info("deptCode = {}", deptId);
+		List<VacationRequestCalendarResponse> vacations
+			= vacationService.selectVacationCalendar(yearMonth, deptId);
+
+		return ResponseEntity.ok(vacations);
+	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/controller/VacationController.java
@@ -1,8 +1,7 @@
 package programmers.team6.domain.vacation.controller;
 
-import java.util.List;
-
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,12 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import programmers.team6.domain.auth.dto.TokenBody;
 import programmers.team6.domain.vacation.dto.VacationCancelResponseDto;
 import programmers.team6.domain.vacation.dto.VacationCreateRequestDto;
 import programmers.team6.domain.vacation.dto.VacationCreateResponseDto;
 import programmers.team6.domain.vacation.dto.VacationInfoSelectResponseDto;
 import programmers.team6.domain.vacation.dto.VacationListResponseDto;
-import programmers.team6.domain.vacation.dto.VacationRequestCalendarResponse;
 import programmers.team6.domain.vacation.dto.VacationUpdateRequestDto;
 import programmers.team6.domain.vacation.dto.VacationUpdateResponseDto;
 import programmers.team6.domain.vacation.service.VacationService;
@@ -34,9 +33,11 @@ public class VacationController {
 
 	private final VacationService vacationService;
 
-	@GetMapping("/my/{memberId}")
+	@GetMapping("/my")
 	public ResponseEntity<VacationInfoSelectResponseDto> getMyVacationInfo(
-		@PathVariable Long memberId) {
+		@AuthenticationPrincipal TokenBody tokenBody) {
+
+		Long memberId = tokenBody.id();
 
 		// 휴가 정보 조회
 		VacationInfoSelectResponseDto vacationInfo = vacationService.getMyVacationInfo(memberId);
@@ -45,39 +46,46 @@ public class VacationController {
 	}
 
 	// 휴가 신청
-	@PostMapping("/{memberId}")
+	@PostMapping
 	public ResponseEntity<VacationCreateResponseDto> requestVacation(
 		@Validated @RequestBody VacationCreateRequestDto requestDto,
-		@PathVariable Long memberId) {
+		@AuthenticationPrincipal TokenBody tokenBody) {
+
+		Long memberId = tokenBody.id();
 		VacationCreateResponseDto response = vacationService.requestVacation(memberId, requestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	// 휴가 신청 리스트 (페이징 조회)
-	@GetMapping("/{memberId}")
+	@GetMapping
 	public ResponseEntity<VacationListResponseDto> getVacationRequestList(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@RequestParam(defaultValue = "0") int page) {
 
+		Long memberId = tokenBody.id();
 		VacationListResponseDto response = vacationService.getVacationRequestList(memberId, page);
 		return ResponseEntity.ok(response);
 	}
 
 	// 휴가 신청 수정
-	@PutMapping("/{memberId}/{requestId}")
+	@PutMapping("/{requestId}")
 	public ResponseEntity<VacationUpdateResponseDto> updateVacationRequest(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@PathVariable Long requestId,
 		@Validated @RequestBody VacationUpdateRequestDto requestDto) {
+
+		Long memberId = tokenBody.id();
 		VacationUpdateResponseDto response = vacationService.updateVacationRequest(memberId, requestId, requestDto);
 		return ResponseEntity.ok(response);
 	}
 
 	// 대기중인 휴가 신청 취소
-	@DeleteMapping("/{memberId}/{requestId}")
+	@DeleteMapping("/{requestId}")
 	public ResponseEntity<?> cancelVacationRequest(
-		@PathVariable Long memberId,
+		@AuthenticationPrincipal TokenBody tokenBody,
 		@PathVariable Long requestId) {
+
+		Long memberId = tokenBody.id();
 
 		boolean success = vacationService.cancelVacationRequest(memberId, requestId);
 
@@ -87,16 +95,6 @@ public class VacationController {
 			.message("휴가 신청이 성공적으로 취소되었습니다.")
 			.build();
 		return ResponseEntity.ok(response);
-	}
-
-	@GetMapping("/calendar")
-	public ResponseEntity<?> selectVacationCalendar(@RequestParam String yearMonth, @RequestParam Long deptId) {
-		log.info("yearMonth = {}", yearMonth);
-		log.info("deptCode = {}", deptId);
-		List<VacationRequestCalendarResponse> vacations
-			= vacationService.selectVacationCalendar(yearMonth, deptId);
-
-		return ResponseEntity.ok(vacations);
 	}
 
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/vacation/service/VacationService.java
@@ -77,11 +77,11 @@ public class VacationService {
 	@Transactional
 	public VacationCreateResponseDto requestVacation(Long memberId, VacationCreateRequestDto requestDto) {
 		// 신청자 정보 조회
-		Member requester = memberRepository.findByIdWithDeptAndLeader(memberId)
+		Member member = memberRepository.findByIdWithDeptAndLeader(memberId)
 			.orElseThrow(() -> new RuntimeException("멤버 정보를 찾을 수 없습니다."));
 
 		// 부서장 조회 (결재자)
-		Dept dept = requester.getDept();
+		Dept dept = member.getDept();
 		Member approver = dept.getDeptLeader();
 
 		// 휴가 유형 코드 조회
@@ -92,7 +92,7 @@ public class VacationService {
 		VacationRequestStatus status = VacationRequestStatus.IN_PROGRESS;
 
 		// 휴가 요청 생성
-		VacationRequest vacationRequest = vacationMapper.toVacationRequest(requestDto, vacationType, status, requester);
+		VacationRequest vacationRequest = vacationMapper.toVacationRequest(requestDto, vacationType, status, member);
 		vacationRequestRepository.save(vacationRequest);
 
 		// 결재 단계 생성


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #102 

## 📝작업 내용
- JWT 토큰을 통해 로그인한 사용자 정보에서 memberId 조회
```
// 휴가 신청
	@PostMapping
	public ResponseEntity<VacationCreateResponseDto> requestVacation(
		@Validated @RequestBody VacationCreateRequestDto requestDto,
		@AuthenticationPrincipal TokenBody tokenBody) {

		Long memberId = tokenBody.id();
		VacationCreateResponseDto response = vacationService.requestVacation(memberId, requestDto);
		return ResponseEntity.ok(response);
	}
```
- service의 requester 변수명을 member로 변경
```
// 신청자 정보 조회
		Member member = memberRepository.findByIdWithDeptAndLeader(memberId)
			.orElseThrow(() -> new RuntimeException("멤버 정보를 찾을 수 없습니다."));
```

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- memberId를 매개변수로 받고 있어서, JWT 토큰으로 받게 수정했습니다 !
