### PR TITLE
fix(119) : 사용자만 검색하도록 변경

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
@@ -41,7 +41,7 @@ public class MemberSearchRepository {
 
 		List<Predicate> predicates = CriteriaCustomPredicateBuilder.<Member>builder(criteriaBuilder)
 			.applyLikeFilter(from, name, Member_.name)
-			.applyNonEqualFilter(from, Role.PENDING, Member_.role)
+			.applyEqualFilter(from, Role.USER, Member_.role)
 			.build();
 
 		return CriteriaCustomQueryBuilder.builder(criteriaQuery, criteriaBuilder)


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #119 

## 📝작업 내용
- 수정화면에서 관리자의 vacation정보들이 비어 있어서 전체저장이 동작하지 않아 수정합니다.
- 관리자는 필터링하여 보이지 않게 진행하엿습니다.



