### PR TITLE
Feat(127) : 휴가 수정 및 통계 페이지 부서별 필터링 로직 추가

### DIFF
--- a/backend/team6/src/main/java/programmers/team6/domain/admin/controller/AdminVacationInfoController.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/controller/AdminVacationInfoController.java
@@ -38,8 +38,8 @@ public class AdminVacationInfoController {
 	@GetMapping
 	@ResponseStatus(value = HttpStatus.OK)
 	public Page<MemberVacationInfoSelectResponse> selectVacationInfos(@PagingConfig(sort = "id") Pageable pageable,
-		@RequestParam(required = false) String name) {
-		Page<Member> members = memberSearchRepository.searchFrom(name, pageable);
+		@RequestParam(required = false) Long deptId, @RequestParam(required = false) String name) {
+		Page<Member> members = memberSearchRepository.searchFrom(name, deptId, pageable);
 		List<VacationInfo> vacationInfos = vacationInfoRepository.findByMemberIdIn(toIds(members));
 		return vacationInfoMapper.toMemberVacationInfoSelectResponsePageFrom(members, vacationInfos);
 	}

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/dto/VacationStatisticsRequest.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/dto/VacationStatisticsRequest.java
@@ -6,5 +6,6 @@ import programmers.team6.domain.vacation.enums.VacationCode;
 import programmers.team6.global.validator.EnumValue;
 
 public record VacationStatisticsRequest(@Positive Integer year, String name,
+										Long deptId,
 										@EnumValue(enumClass = VacationCode.class, fieldName = "code") @NotEmpty String vacationCode) {
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/service/MemberReader.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/service/MemberReader.java
@@ -3,27 +3,28 @@ package programmers.team6.domain.admin.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import programmers.team6.domain.admin.dto.VacationStatisticsRequest;
-import programmers.team6.domain.member.repository.MemberRepository;
+import programmers.team6.domain.member.entity.Member;
+import programmers.team6.domain.member.repository.MemberSearchRepository;
 
 @Component
 @RequiredArgsConstructor
 public class MemberReader {
 
-	private final MemberRepository memberRepository;
+	private final MemberSearchRepository memberRepository;
+	private final VacationInfoLogSearchRepository vacationInfoLogSearchRepository;
 
 	public Members readHasVacationInfoMemberFrom(VacationStatisticsRequest request, Pageable pageable) {
 		LocalDateTime date = LocalDateTime.of(request.year(), 12, 31, 23, 59);
-		if (request.name() == null) {
-			return new Members(
-				memberRepository.findAllHasVacationInfoTargetYear(date, request.vacationCode(), pageable));
-		}
-		return new Members(
-			memberRepository.findAllHasVacationInfoTargetYear(date,  request.vacationCode(), request.name(), pageable));
-	}
 
+		List<Long> ids = vacationInfoLogSearchRepository.queryContainVacationInfoMemberIds(date,
+			request.vacationCode());
+		Page<Member> members = memberRepository.searchFrom(request.deptId(), request.name(), ids, pageable);
+		return new Members(members);
+	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/service/VacationInfoLogSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/service/VacationInfoLogSearchRepository.java
@@ -38,7 +38,6 @@ public class VacationInfoLogSearchRepository {
 			.projection(Long.class, from.get(VacationInfoLog_.memberId))
 			.createQuery(entityManager)
 			.build();
-		List<Long> resultList = build.getResultList();
-		return resultList;
+		return  build.getResultList();
 	}
 }

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/service/VacationInfoLogSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/service/VacationInfoLogSearchRepository.java
@@ -1,0 +1,44 @@
+package programmers.team6.domain.admin.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import programmers.team6.domain.admin.utils.CriteriaCustomPredicateBuilder;
+import programmers.team6.domain.admin.utils.CriteriaCustomQueryBuilder;
+import programmers.team6.domain.vacation.entity.VacationInfoLog;
+import programmers.team6.domain.vacation.entity.VacationInfoLog_;
+
+@Repository
+@RequiredArgsConstructor
+public class VacationInfoLogSearchRepository {
+
+	private final EntityManager entityManager;
+
+	public List<Long> queryContainVacationInfoMemberIds(LocalDateTime localDateTime, String code) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
+		Root<VacationInfoLog> from = criteriaQuery.from(VacationInfoLog.class);
+
+		List<Predicate> predicates = CriteriaCustomPredicateBuilder.<VacationInfoLog>builder(criteriaBuilder)
+			.applyEqualFilter(from, code, VacationInfoLog_.vacationType)
+			.build();
+		predicates.add(criteriaBuilder.lessThanOrEqualTo(from.get(VacationInfoLog_.logDate), localDateTime));
+
+		TypedQuery<Long> build = CriteriaCustomQueryBuilder.builder(criteriaQuery, criteriaBuilder)
+			.applyDynamicPredicates(predicates)
+			.projection(Long.class, from.get(VacationInfoLog_.memberId))
+			.createQuery(entityManager)
+			.build();
+		List<Long> resultList = build.getResultList();
+		return resultList;
+	}
+}

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/utils/CriteriaCustomPredicateBuilder.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/utils/CriteriaCustomPredicateBuilder.java
@@ -1,12 +1,15 @@
 package programmers.team6.domain.admin.utils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.SingularAttribute;
 import programmers.team6.domain.admin.enums.Quarter;
 

--- a/backend/team6/src/main/java/programmers/team6/domain/admin/utils/CriteriaCustomPredicateBuilder.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/admin/utils/CriteriaCustomPredicateBuilder.java
@@ -1,15 +1,12 @@
 package programmers.team6.domain.admin.utils;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.From;
-import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.SingularAttribute;
 import programmers.team6.domain.admin.enums.Quarter;
 

--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import programmers.team6.domain.admin.utils.CriteriaCustomPredicateBuilder;
 import programmers.team6.domain.admin.utils.CriteriaCustomQueryBuilder;
 import programmers.team6.domain.admin.utils.QueryUtils;
+import programmers.team6.domain.member.entity.Dept_;
 import programmers.team6.domain.member.entity.Member;
 import programmers.team6.domain.member.entity.Member_;
 import programmers.team6.domain.member.enums.Role;
@@ -28,13 +29,13 @@ public class MemberSearchRepository {
 
 	private final EntityManager entityManager;
 
-	public Page<Member> searchFrom(String name, Pageable pageable) {
-		TypedQuery<Member> query = createSearchQueryFrom(name, pageable);
+	public Page<Member> searchFrom(String name, Long deptId, Pageable pageable) {
+		TypedQuery<Member> query = createSearchQueryFrom(name, deptId, pageable);
 		long count = createSearCountFrom(name);
 		return QueryUtils.makeQueryToPageable(query, pageable, count);
 	}
 
-	private TypedQuery<Member> createSearchQueryFrom(String name, Pageable pageable) {
+	private TypedQuery<Member> createSearchQueryFrom(String name, Long deptId, Pageable pageable) {
 		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<Member> criteriaQuery = criteriaBuilder.createQuery(Member.class);
 		Root<Member> from = criteriaQuery.from(Member.class);
@@ -42,6 +43,7 @@ public class MemberSearchRepository {
 		List<Predicate> predicates = CriteriaCustomPredicateBuilder.<Member>builder(criteriaBuilder)
 			.applyLikeFilter(from, name, Member_.name)
 			.applyEqualFilter(from, Role.USER, Member_.role)
+			.applyEqualFilter(from, deptId, Member_.dept, Dept_.id)
 			.build();
 
 		return CriteriaCustomQueryBuilder.builder(criteriaQuery, criteriaBuilder)

--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
@@ -12,7 +12,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +54,7 @@ public class MemberSearchRepository {
 		predicates.add(inClause); // inClause가 별도로 존재한다고 가정
 
 		criteriaQuery.where(criteriaBuilder.and(predicates.toArray(new Predicate[0])));
-		TypedQuery<Member> query =  CriteriaCustomQueryBuilder.builder(
+		TypedQuery<Member> query = CriteriaCustomQueryBuilder.builder(
 				criteriaQuery, criteriaBuilder)
 			.orderBy(from, pageable.getSort())
 			.createQuery(entityManager)

--- a/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
+++ b/backend/team6/src/main/java/programmers/team6/domain/member/repository/MemberSearchRepository.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,57 @@ public class MemberSearchRepository {
 		TypedQuery<Member> query = createSearchQueryFrom(name, deptId, pageable);
 		long count = createSearCountFrom(name);
 		return QueryUtils.makeQueryToPageable(query, pageable, count);
+	}
+
+	public Page<Member> searchFrom(Long deptId, String name, List<Long> ids, Pageable pageable) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Member> criteriaQuery = criteriaBuilder.createQuery(Member.class);
+		Root<Member> from = criteriaQuery.from(Member.class);
+
+		CriteriaBuilder.In<Long> inClause = criteriaBuilder.in(from.get(Member_.id));
+		for (Long id : ids) {
+			inClause.value(id);
+		}
+
+		List<Predicate> predicates = CriteriaCustomPredicateBuilder.<Member>builder(criteriaBuilder)
+			.applyLikeFilter(from, name, Member_.name)
+			.applyEqualFilter(from, deptId, Member_.dept, Dept_.id)
+			.build();
+
+		// in 절 포함해서 전체 조건 생성
+		predicates.add(inClause); // inClause가 별도로 존재한다고 가정
+
+		criteriaQuery.where(criteriaBuilder.and(predicates.toArray(new Predicate[0])));
+		TypedQuery<Member> query =  CriteriaCustomQueryBuilder.builder(
+				criteriaQuery, criteriaBuilder)
+			.orderBy(from, pageable.getSort())
+			.createQuery(entityManager)
+			.build();
+		return QueryUtils.makeQueryToPageable(query, pageable, countSearchFrom(name, ids));
+	}
+
+	private long countSearchFrom(String name, List<Long> ids) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
+		CriteriaQuery<Long> criteriaQuery = criteriaBuilder.createQuery(Long.class);
+		Root<Member> from = criteriaQuery.from(Member.class);
+
+		criteriaQuery.select(criteriaBuilder.count(from));
+		CriteriaBuilder.In<Long> inClause = criteriaBuilder.in(from.get(Member_.id));
+		for (Long id : ids) {
+			inClause.value(id);
+		}
+
+		List<Predicate> predicates = CriteriaCustomPredicateBuilder.<Member>builder(criteriaBuilder)
+			.applyLikeFilter(from, name, Member_.name)
+			.build();
+
+		criteriaQuery.where(inClause);
+		TypedQuery<Long> query = CriteriaCustomQueryBuilder.builder(criteriaQuery, criteriaBuilder)
+			.applyDynamicPredicates(predicates)
+			.createQuery(entityManager)
+			.build();
+
+		return query.getSingleResult();
 	}
 
 	private TypedQuery<Member> createSearchQueryFrom(String name, Long deptId, Pageable pageable) {
@@ -78,5 +130,4 @@ public class MemberSearchRepository {
 
 		return query.getSingleResult();
 	}
-
 }

--- a/front/team06/src/pages/component/vacations/statistics.jsx
+++ b/front/team06/src/pages/component/vacations/statistics.jsx
@@ -10,18 +10,21 @@ const VacationManagerPage = () => {
     const [selectedYear, setSelectedYear] = useState('2025');
     const [vacationTypesList, setVacationTypesList] = useState([]);
     const [selectedVacationType, setSelectedVacationType] = useState('');
+    const [departments, setDepartments] = useState([]);
+    const [selectedDepartment, setSelectedDepartment] = useState('');
 
     const vacationTypes = ['january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'];
 
     useEffect(() => {
         fetchVacationTypes();
+        fetchDepartments();
     }, []);
 
     useEffect(() => {
         if (selectedVacationType !== '') {
             fetchVacationData();
         }
-    }, [currentPage, selectedYear, selectedVacationType]);
+    }, [currentPage, selectedYear, selectedVacationType, selectedDepartment]);
 
     const fetchVacationTypes = async () => {
         try {
@@ -37,7 +40,7 @@ const VacationManagerPage = () => {
 
             if (filteredTypes.length > 0) {
                 setVacationTypesList(filteredTypes);
-                setSelectedVacationType(filteredTypes[0].code); // ✅ 기본값 설정
+                setSelectedVacationType(filteredTypes[0].code);
             } else {
                 console.error('휴가 타입 응답 형식이 올바르지 않습니다.', response.data);
                 setVacationTypesList([]);
@@ -50,6 +53,16 @@ const VacationManagerPage = () => {
         }
     };
 
+    const fetchDepartments = async () => {
+        try {
+            const res = await axios.get('http://localhost:8080/depts');
+            setDepartments(res.data);
+        } catch {
+            alert('부서 목록을 불러오는 데 실패했습니다.');
+            setDepartments([]);
+        }
+    };
+
     const fetchVacationData = async () => {
         setLoading(true);
         try {
@@ -58,6 +71,7 @@ const VacationManagerPage = () => {
                     year: selectedYear,
                     name: searchName || undefined,
                     vacationCode: selectedVacationType || undefined,
+                    deptId: selectedDepartment || undefined,
                     page: currentPage,
                 },
             });
@@ -90,13 +104,11 @@ const VacationManagerPage = () => {
             <div className="max-w-7xl mx-auto">
                 <div className="mb-6">
                     <h1 className="text-2xl font-bold text-gray-900">휴가 현황</h1>
-                    <p className="text-gray-600 mt-2"></p>
                 </div>
             </div>
 
             {/* 필터 영역 */}
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
-                {/* 상단 필터: 연도 + 휴가 종류 */}
                 <div className="flex flex-wrap items-center gap-6 mb-4">
                     {/* 연도 선택 */}
                     <div className="flex items-center gap-2">
@@ -127,6 +139,22 @@ const VacationManagerPage = () => {
                             ))}
                         </select>
                     </div>
+
+                    {/* 부서 선택 */}
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="department" className="text-gray-700 whitespace-nowrap">부서</label>
+                        <select
+                            id="department"
+                            value={selectedDepartment}
+                            onChange={(e) => setSelectedDepartment(e.target.value)}
+                            className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                        >
+                            <option value="">전체</option>
+                            {departments.map((dept) => (
+                                <option key={dept.id} value={dept.id}>{dept.name}</option>
+                            ))}
+                        </select>
+                    </div>
                 </div>
 
                 {/* 이름 검색 필터 */}
@@ -147,7 +175,6 @@ const VacationManagerPage = () => {
                     </button>
                 </div>
             </div>
-
 
             {/* 테이블 */}
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-x-auto">

--- a/front/team06/src/pages/component/vacations/vacations.jsx
+++ b/front/team06/src/pages/component/vacations/vacations.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect,useRef} from "react";
+import React, {useState, useEffect, useRef} from "react";
 import {Search, Save, ChevronLeft, ChevronRight, Loader2} from "lucide-react";
 import axios from '../../../api/axiosInstance';
 
@@ -14,25 +14,42 @@ const vacationTypes = Object.keys(vacationTypeMap);
 
 export default function Vacations() {
     const [vacationData, setVacationData] = useState([]);
+    const [departments, setDepartments] = useState([]);
     const [loading, setLoading] = useState(true);
     const [searchName, setSearchName] = useState("");
+    const [searchDeptId, setSearchDeptId] = useState("");
     const [currentPage, setCurrentPage] = useState(0);
     const [totalPages, setTotalPages] = useState(1);
     const pageSize = 10;
 
     const requestedRef = useRef(false);
+
+    useEffect(() => {
+        fetchDepartments();
+    }, []);
+
     useEffect(() => {
         if (requestedRef.current) return;
         requestedRef.current = true;
-        fetchVacationData(currentPage, searchName);
+        fetchVacationData(currentPage, searchName, searchDeptId);
     }, [currentPage]);
 
-    const fetchVacationData = async (page, name) => {
+    const fetchDepartments = async () => {
+        try {
+            const res = await axios.get("http://localhost:8080/depts");
+            setDepartments(res.data);
+        } catch {
+            alert("부서 목록을 불러오는 데 실패했습니다.");
+        }
+    };
+
+    const fetchVacationData = async (page, name, deptId) => {
         setLoading(true);
         try {
             const response = await axios.get('/admin/vacations/infos', {
                 params: {
                     name: name,
+                    deptId: deptId || undefined,
                     page: page,
                     size: pageSize
                 }
@@ -43,8 +60,8 @@ export default function Vacations() {
             setTotalPages(data.totalPages || 1);
         } catch (e) {
             if (e.response?.status === 401) {
-               alert('접근 권한이 없습니다.');
-            }else{
+                alert('접근 권한이 없습니다.');
+            } else {
                 alert('데이터 조회 실패');
             }
         } finally {
@@ -72,7 +89,7 @@ export default function Vacations() {
 
     const saveEmployee = async (employee) => {
         try {
-            const response = await axios.patch('/admin/vacations/infos', {
+            await axios.patch('/admin/vacations/infos', {
                 requests: [
                     {
                         memberId: employee.id,
@@ -101,24 +118,9 @@ export default function Vacations() {
                 alert('문제가 발생하였습니다');
             }
         } finally {
-            fetchVacationData(currentPage, searchName);
+            fetchVacationData(currentPage, searchName, searchDeptId);
         }
     };
-
-    const  throwError = async (response) => {
-        let errorData = {};
-        try {
-            errorData = await response.json(); // 서버 에러 메시지 파싱
-        } catch {
-            errorData.message = '알 수 없는 에러';
-        }
-
-        const error = new Error(errorData.message || '저장 실패');
-        error.codeName = errorData.codeName || null;
-        error.status = errorData.status || response.status;
-        error.validationErrors = errorData.errors || null;
-        throw error;
-    }
 
     const handleSaveAll = async () => {
         try {
@@ -132,7 +134,7 @@ export default function Vacations() {
                 })),
             }));
 
-            const response = await axios.patch('/admin/vacations/infos', { requests });
+            await axios.patch('/admin/vacations/infos', {requests});
 
             alert('전체 저장 완료');
         } catch (e) {
@@ -149,7 +151,7 @@ export default function Vacations() {
                 alert('문제가 발생하였습니다');
             }
         } finally {
-            fetchVacationData(currentPage, searchName);
+            fetchVacationData(currentPage, searchName, searchDeptId);
         }
     };
 
@@ -161,7 +163,7 @@ export default function Vacations() {
 
     const handleSearch = () => {
         setCurrentPage(0);
-        fetchVacationData(0, searchName);
+        fetchVacationData(0, searchName, searchDeptId);
     };
 
     return (
@@ -174,6 +176,7 @@ export default function Vacations() {
                     </p>
                 </div>
             </div>
+
             {/* 필터 영역 */}
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
                 <h2 className="text-lg font-semibold text-gray-800 mb-4">
@@ -181,28 +184,42 @@ export default function Vacations() {
                 </h2>
                 <div className="space-y-4">
                     <div className="flex flex-wrap items-center justify-between gap-4">
-                        <div className="relative">
-                            <div className="flex items-center">
-                                <div className="relative">
-                                    <input
-                                        type="text"
-                                        value={searchName}
-                                        placeholder="이름 검색"
-                                        onChange={e => setSearchName(e.target.value)}
-                                        onKeyDown={e => e.key === "Enter" && handleSearch()}
-                                        className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 w-64 transition-all"
-                                    />
-                                    <div className="absolute left-3 top-2.5 text-gray-400">
-                                        <Search size={18}/>
-                                    </div>
+                        <div className="flex items-center gap-3">
+                            {/* 부서 필터 */}
+                            <select
+                                value={searchDeptId}
+                                onChange={e => setSearchDeptId(e.target.value)}
+                                className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            >
+                                <option value="">전체 부서</option>
+                                {departments.map(dept => (
+                                    <option key={dept.id} value={dept.id}>
+                                        {dept.name}
+                                    </option>
+                                ))}
+                            </select>
+
+                            {/* 이름 검색 */}
+                            <div className="relative">
+                                <input
+                                    type="text"
+                                    value={searchName}
+                                    placeholder="이름 검색"
+                                    onChange={e => setSearchName(e.target.value)}
+                                    onKeyDown={e => e.key === "Enter" && handleSearch()}
+                                    className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 w-64 transition-all"
+                                />
+                                <div className="absolute left-3 top-2.5 text-gray-400">
+                                    <Search size={18}/>
                                 </div>
-                                <button
-                                    onClick={handleSearch}
-                                    className="ml-2 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition-colors duration-200 font-medium flex items-center gap-1"
-                                >
-                                    검색
-                                </button>
                             </div>
+
+                            <button
+                                onClick={handleSearch}
+                                className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition-colors duration-200 font-medium flex items-center gap-1"
+                            >
+                                검색
+                            </button>
                         </div>
 
                         <button
@@ -216,11 +233,11 @@ export default function Vacations() {
                 </div>
             </div>
 
-            {/* 테이블 */}
+            {/* 테이블 영역 */}
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
                 {loading ? (
                     <div className="flex justify-center items-center py-12">
-                        <Loader2 className="animate-spin text-blue-500" size={32} />
+                        <Loader2 className="animate-spin text-blue-500" size={32}/>
                         <span className="ml-2 text-gray-600">데이터를 불러오는 중...</span>
                     </div>
                 ) : (
@@ -274,7 +291,8 @@ export default function Vacations() {
                             ))}
                             {vacationData.length === 0 && (
                                 <tr>
-                                    <td colSpan={vacationTypes.length + 2} className="px-4 py-8 text-center text-gray-500 border-b border-gray-200">
+                                    <td colSpan={vacationTypes.length + 2}
+                                        className="px-4 py-8 text-center text-gray-500 border-b border-gray-200">
                                         검색 결과가 없습니다.
                                     </td>
                                 </tr>
@@ -292,14 +310,14 @@ export default function Vacations() {
                             disabled={currentPage === 0}
                             className="flex items-center px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:bg-gray-100 transition-colors duration-200"
                         >
-                            <ChevronLeft size={16} />
+                            <ChevronLeft size={16}/>
                             <span className="ml-1 font-medium">이전</span>
                         </button>
 
                         <div className="flex items-center">
-              <span className="px-3 py-1 bg-blue-100 text-blue-700 font-medium rounded-md">
-                {currentPage + 1}
-              </span>
+                            <span className="px-3 py-1 bg-blue-100 text-blue-700 font-medium rounded-md">
+                                {currentPage + 1}
+                            </span>
                             <span className="mx-2 text-gray-600">of</span>
                             <span className="text-gray-700">{totalPages}</span>
                         </div>
@@ -310,7 +328,7 @@ export default function Vacations() {
                             className="flex items-center px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:bg-gray-100 transition-colors duration-200"
                         >
                             <span className="mr-1 font-medium">다음</span>
-                            <ChevronRight size={16} />
+                            <ChevronRight size={16}/>
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #127 

## 📝작업 내용
- 휴가 수정 페이지 부서 검색 로직 추가
<img width="657" alt="스크린샷 2025-05-21 오전 10 06 56" src="https://github.com/user-attachments/assets/e7357a95-29fd-4dbb-ba8c-11ca68056b7f" />

- 휴가 통계 페이지 부서 검색 로직 추가
<img width="657" alt="스크린샷 2025-05-21 오전 10 06 35" src="https://github.com/user-attachments/assets/b19b7a4c-0d23-43ad-9291-aeb2c6fa7d0c" />

## 🧪 테스트 여부
- [x] 테스트를 수행함
